### PR TITLE
enable LUA support for net/haproxy-devel

### DIFF
--- a/config/18.1/make.conf
+++ b/config/18.1/make.conf
@@ -47,6 +47,7 @@ net_asterisk13_UNSET=		DAHDI XMPP
 net_freeradius3_SET=		LDAP MITKRB_PORT SQLITE3
 net_freeradius3_UNSET=		HEIMDAL
 net_haproxy_SET=		LUA
+net_haproxy-devel_SET=		LUA
 net_igmpproxy_SET=		VLANFIX
 net_openldap24-server_SET=	MEMBEROF REFINT SASL
 net_vnstat_UNSET=		GUI


### PR DESCRIPTION
Without LUA support HAProxy will fail to start, rendering the HAProxy plugin unusable.
This is required to be able to switch to HAProxy 1.8 for OPNsense 18.1.

Refs https://github.com/opnsense/plugins/issues/224