### PR TITLE
fix an error making the script stop building!

### DIFF
--- a/build/vm.sh
+++ b/build/vm.sh
@@ -101,6 +101,7 @@ elif [ -n "${VMSWAP}" -a -n "${UEFIBOOT}" ]; then
 	GPTDUMMY=
 fi
 
+fuser -cuk ${STAGEDIR}/mnt
 umount ${STAGEDIR}/mnt
 mdconfig -d -u ${DEV}
 


### PR DESCRIPTION
An error occur when you try to build a vm image.
"umount ${STAGEDIR}/mnt": will cause an error if the folder been used from another processes.

The build will stop and will show: 
>umount: unmount of /usr/obj/usr/tools/config/18.7/OpenSSL:amd64/mnt failed:      Device busy

The output: 

```
>>> Begin extra: vm_hook
rc.loader: assembling banner
rc.loader: assembling brand
rc.loader: assembling misc
rc.loader: assembling modules
rc.loader: assembling netgraph
>>> End extra: vm_hook
>>> Setting up entropy in /usr/obj/usr/tools/config/18.7/OpenSSL:amd64/mnt
1+0 records in
1+0 records out
4096 bytes transferred in 0.000068 secs (60374689 bytes/sec)
1+0 records in
1+0 records out
4096 bytes transferred in 0.000064 secs (63777774 bytes/sec)
umount: unmount of /usr/obj/usr/tools/config/18.7/OpenSSL:amd64/mnt failed: Device busy
*** Error code 1

Stop.
make: stopped in /usr/tools
```

The output of "fstat /usr/obj/usr/tools/config/18.7/OpenSSL:amd64/mnt":
```
USER     CMD          PID   FD MOUNT      INUM MODE         SZ|DV R/W NAME
root     python2.7  47858 root /usr/obj/usr/tools/config/18.7/OpenSSL:amd64/mnt      2 drwxr-xr-x     512  r  /usr/obj/usr/tools/config/18.7/OpenSSL:amd64/mnt/
root     python2.7  47858 jail /usr/obj/usr/tools/config/18.7/OpenSSL:amd64/mnt      2 drwxr-xr-x     512  r  /usr/obj/usr/tools/config/18.7/OpenSSL:amd64/mnt/
root     python2.7  47470   wd /usr/obj/usr/tools/config/18.7/OpenSSL:amd64/mnt      2 drwxr-xr-x     512  r  /usr/obj/usr/tools/config/18.7/OpenSSL:amd64/mnt/
root     python2.7  47470 root /usr/obj/usr/tools/config/18.7/OpenSSL:amd64/mnt      2 drwxr-xr-x     512  r  /usr/obj/usr/tools/config/18.7/OpenSSL:amd64/mnt/
root     python2.7  47470 jail /usr/obj/usr/tools/config/18.7/OpenSSL:amd64/mnt      2 drwxr-xr-x     512  r  /usr/obj/usr/tools/config/18.7/OpenSSL:amd64/mnt/
```
To fix this error we should kill all processes using /mnt/ folder before umount it.
and one way to do it, is using fuser.

After adding the line the building script worked fine.

-- Khaled