### PR TITLE
Add apuledctld support for using on PCEngines APU<x> devices (from Smart-Soft)

### DIFF
--- a/config/18.7/ports.conf
+++ b/config/18.7/ports.conf
@@ -130,6 +130,7 @@ net/wireguard					arm,i386
 net/wol
 net/zerotier					arm
 opnsense/apinger
+opnsense/apuledctld				arm
 opnsense/bsdinstaller				arm,quick
 opnsense/cpustats
 opnsense/dhcp6c

--- a/config/19.1/ports.conf
+++ b/config/19.1/ports.conf
@@ -130,6 +130,7 @@ net/wireguard					arm,i386
 net/wol
 net/zerotier					arm
 opnsense/apinger
+opnsense/apuledctld				arm
 opnsense/bsdinstaller				arm,quick
 opnsense/cpustats
 opnsense/dhcp6c


### PR DESCRIPTION
To implement as described in opnsense/core#2114