### PR TITLE
build arm: fix bananapi.dtb file name

### DIFF
--- a/build/arm.sh
+++ b/build/arm.sh
@@ -100,7 +100,7 @@ cp -p ${STAGEDIR}/boot/ubldr.bin ${STAGEDIR}/boot/msdos/ubldr.bin
 
 case "${PRODUCT_DEVICE}" in
 bpi)
-	cp -p ${STAGEDIR}/boot/dtb/sun7i-a20-bananapi.dtb ${STAGEDIR}/boot/msdos/sun7i-a20-bananapi.dtb
+	cp -p ${STAGEDIR}/boot/dtb/bananapi.dtb ${STAGEDIR}/boot/msdos/sun7i-a20-bananapi.dtb
 	cp -p /usr/local/share/u-boot/u-boot-bananapi/* ${STAGEDIR}/boot/msdos
 	;;
 odroid-xu3)


### PR DESCRIPTION
Need to test bananapi image first from https://drive.google.com/drive/folders/1bAWuECNJwu0LdJOpaIn-2MrTKZ8evGNY. If it boots, this should be safe to merge. Else need to rename the copied bananapi.dtb too.