### PR TITLE
device: in case BANANAPI img won't boot

### DIFF
--- a/device/BANANAPI.conf
+++ b/device/BANANAPI.conf
@@ -25,4 +25,8 @@ arm_install_uboot()
 	cp ${ARM_UBOOT_DIR}/boot.scr ${STAGEDIR}/boot/msdos
 	cp -p ${STAGEDIR}/boot/ubldr.bin ${STAGEDIR}/boot/msdos
 	ln ${STAGEDIR}/boot/dtb/bananapi.dtb ${STAGEDIR}/boot/dtb/sun7i-a20-bananapi.dtb
+	
+	# XXX because .dtb loaded from MSDOS partition (mount_msdosfs /dev/${DEV}s1 ${STAGEDIR}/boot/msdos)
+	cp -p ${STAGEDIR}/boot/dtb/bananapi.dtb ${STAGEDIR}/boot/msdos/bananapi.dtb
+	ln ${STAGEDIR}/boot/msdos/bananapi.dtb ${STAGEDIR}/boot/msdos/sun7i-a20-bananapi.dtb
 }


### PR DESCRIPTION
@fichtner 
Copying dtb files to msdos directory instead of dtb directory.