### PR TITLE
keep HAProxy 1.8.x

### DIFF
--- a/config/19.1/ports.conf
+++ b/config/19.1/ports.conf
@@ -109,6 +109,7 @@ net/frr5					arm,arm64
 net/frr6					arm,arm64
 #net/frr7					arm,arm64
 net/haproxy					arm,arm64
+net/haproxy18					arm,arm64
 net/hostapd
 net/igmpproxy
 net/isc-dhcp44-relay


### PR DESCRIPTION
The FreeBSD port net/haproxy was recently switched to the 1.9 release series of HAProxy. As stated in https://github.com/opnsense/plugins/issues/1089 I'd rather stay on 1.8.x until 2.0 was released and stabilized.

HAProxy 1.8 moved to a new port:
https://www.freshports.org/net/haproxy18