### PR TITLE
obsolete: fix build machines collate order differences

### DIFF
--- a/build/base.sh
+++ b/build/base.sh
@@ -88,12 +88,13 @@ echo -n ">>> Generating obsolete file list... "
 
 : > ${STAGEDIR}/setdiff.old
 if [ -f ${CONFIGDIR}/plist.base.${PRODUCT_ARCH} ]; then
-	cp ${CONFIGDIR}/plist.base.${PRODUCT_ARCH} ${STAGEDIR}/setdiff.old
+	sort -u < ${CONFIGDIR}/plist.base.${PRODUCT_ARCH} > ${STAGEDIR}/setdiff.old
 fi
 
 : > ${STAGEDIR}/setdiff.tmp
 if [ -f ${CONFIGDIR}/plist.obsolete.${PRODUCT_ARCH} ]; then
-	diff -u ${CONFIGDIR}/plist.obsolete.${PRODUCT_ARCH} \
+	sort -u < ${CONFIGDIR}/plist.obsolete.${PRODUCT_ARCH} > ${STAGEDIR}/setdiff.sort
+	diff -u ${STAGEDIR}/setdiff.sort \
 	    ${STAGEDIR}/setdiff.new | grep '^-/' | \
 	    cut -b 2- > ${STAGEDIR}/setdiff.tmp
 fi


### PR DESCRIPTION
Last times, if I build base, I get broken obsolete file in result. Because some files has other sort order in generated sorted file list then obsolete file from repository. As result, diff generates '+' and '-' records for this files, as they are moved in sort order. And then filters out '+' records and generates extra records in obsolete file. And during system update, those files deleted and system becomes broken.