### PR TITLE
os-sunnyvalley: we can enable the build for LibreSSL

### DIFF
--- a/config/19.7/plugins.conf
+++ b/config/19.7/plugins.conf
@@ -62,7 +62,7 @@ sysutils/nut					arm,arm64
 sysutils/smart					arm,arm64
 sysutils/vmware					arm,arm64
 sysutils/xen					arm,arm64
-vendor/sunnyvalley				arm,arm64,i386,LibreSSL
+vendor/sunnyvalley				arm,arm64,i386
 www/c-icap					arm,arm64
 www/cache
 www/nginx					arm,arm64


### PR DESCRIPTION
we can enable the build for LibreSSL since os-sensei does not specifically depend on OpenSSL/LibreSSL for now. The same holds true for elasticsearch5.