### PR TITLE
keep HAProxy 2.0, upstream port was renamed

### DIFF
--- a/config/20.7/ports.conf
+++ b/config/20.7/ports.conf
@@ -106,7 +106,7 @@ net/freeradius3					arm,arm64
 net/freevrrpd					arm,arm64
 net/frr7					arm,arm64
 net/google-cloud-sdk				arm,arm64
-net/haproxy					arm,arm64
+net/haproxy20					arm,arm64
 net/hostapd
 net/igmpproxy
 net/isc-dhcp44-relay


### PR DESCRIPTION
The upstream port was renamed from `net/haproxy` to `net/haproxy20`. Now the old port is HAProxy 2.2, but we should keep HAProxy 2.0 for the time being.