### PR TITLE
Fixed object paths for cross compiling

### DIFF
--- a/build/base.sh
+++ b/build/base.sh
@@ -68,7 +68,11 @@ BASE_OBJDIR="$(make -C${SRCDIR}/release -V .OBJDIR)"
 setup_stage "${BASE_OBJDIR}/${BASE_DISTDIR}"
 
 # remove older object archives, too
-BASE_OBJ=$(make -C${SRCDIR}/release -V .OBJDIR)/base.txz
+if [ ${PRODUCT_HOST} != ${PRODUCT_ARCH} ]; then
+        BASE_OBJ=$(make -C/usr/obj${SRCDIR}/${PRODUCT_TARGET}.${PRODUCT_ARCH}/release -V .OBJDIR)/base.txz
+else
+        BASE_OBJ=$(make -C${SRCDIR}/release -V .OBJDIR)/base.txz
+fi
 rm -f ${BASE_OBJ}
 
 ${ENV_FILTER} make -s -C${SRCDIR}/release base.txz ${MAKE_ARGS}

--- a/build/kernel.sh
+++ b/build/kernel.sh
@@ -58,6 +58,8 @@ __MAKE_CONF=
 ${MAKE_ARGS_DEV}
 "
 
+echo ">>>>>> DEBUG: ${MAKE_ARGS}"
+
 if [ ${PRODUCT_HOST} != ${PRODUCT_ARCH} ]; then
 	${ENV_FILTER} make -s -C${SRCDIR} -j${CPUS} kernel-toolchain ${MAKE_ARGS}
 fi
@@ -70,8 +72,13 @@ KERNEL_OBJDIR="$(make -C${SRCDIR}/release -V .OBJDIR)"
 setup_stage "${KERNEL_OBJDIR}/${KERNEL_DISTDIR}"
 
 # remove older object archives, too
-KERNEL_OBJ=$(make -C${SRCDIR}/release -V .OBJDIR)/kernel.txz
-DEBUG_OBJ=$(make -C${SRCDIR}/release -V .OBJDIR)/kernel-dbg.txz
+if [ ${PRODUCT_HOST} != ${PRODUCT_ARCH} ]; then
+        KERNEL_OBJ=$(make -C/usr/obj/${SRCDIR}/${PRODUCT_TARGET}.${PRODUCT_ARCH}/release -V .OBJDIR)/kernel.txz
+        DEBUG_OBJ=$(make -C/usr/obj/${SRCDIR}/${PRODUCT_TARGET}.${PRODUCT_ARCH}/release -V .OBJDIR)/kernel-dbg.txz
+else
+        KERNEL_OBJ=$(make -C${SRCDIR}/release -V .OBJDIR)/kernel.txz
+        DEBUG_OBJ=$(make -C${SRCDIR}/release -V .OBJDIR)/kernel-dbg.txz
+fi
 rm -f ${KERNEL_OBJ} ${DEBUG_OBJ}
 
 # We used kernel.txz because we did not rewrite it,

--- a/build/kernel.sh
+++ b/build/kernel.sh
@@ -58,8 +58,6 @@ __MAKE_CONF=
 ${MAKE_ARGS_DEV}
 "
 
-echo ">>>>>> DEBUG: ${MAKE_ARGS}"
-
 if [ ${PRODUCT_HOST} != ${PRODUCT_ARCH} ]; then
 	${ENV_FILTER} make -s -C${SRCDIR} -j${CPUS} kernel-toolchain ${MAKE_ARGS}
 fi


### PR DESCRIPTION
References to #181 , sorry for the duplicate.

As complained in [https://wiki.freebsd.org/A_Brief_Guide_To_Cross_Compiling_FreeBSD](https://wiki.freebsd.org/A_Brief_Guide_To_Cross_Compiling_FreeBSD), where $TARGET != $TARGET_ARCH, the object dir is "$MAKEOBJDIRPREFIX/$TARGET.$TARGET_ARCH"

So in this case -> /usr/obj/$TARGET.$TARGET_ARCH