### PR TITLE
Remove unset GUI from vnstat build config.

### DIFF
--- a/config/20.7/make.conf
+++ b/config/20.7/make.conf
@@ -66,7 +66,6 @@ net_haproxy_SET=		LUA
 net_haproxy20_SET=		LUA
 net_miniupnpd_SET=		CHECK_PORTINUSE PF_FILTER_RULES
 net_openldap24-server_SET=	MEMBEROF REFINT SASL
-net_vnstat_UNSET=		GUI
 security_acme.sh_SET=		BINDTOOLS EXAMPLES
 security_autossh_SET=		SSH_PORTABLE
 security_ca_root_nss_UNSET=	ETCSYMLINK


### PR DESCRIPTION
In theory this will cause `vnstati` to get built. The catch is that now the `gd` package will become a required dependency for `vnstat` ...

This is the first step towards addressing https://github.com/opnsense/ports/issues/103