### PR TITLE
Add beats7 to ports.conf

### DIFF
--- a/config/21.1/ports.conf
+++ b/config/21.1/ports.conf
@@ -192,6 +192,7 @@ sysutils/ansible@py${PRODUCT_PYTHON}		arm,arm64
 sysutils/apcupsd				arm,arm64
 sysutils/beadm					arm,arm64
 sysutils/beats6					arm,arm64
+sysutils/beats7					arm,arm64
 sysutils/burp					arm,arm64
 sysutils/cciss_vol_status			arm,arm64
 sysutils/consul					arm,arm64


### PR DESCRIPTION
As Elasticsearch 8 is on it's way and beats6 isn't compatible with Elastic Common Schema (ECS) I would like to finally add beats7 before the Elasticsearch 8 release.