### PR TITLE
Add poudriere to package list

### DIFF
--- a/config/21.1/ports.conf
+++ b/config/21.1/ports.conf
@@ -166,6 +166,7 @@ opnsense/phpseclib@php${PRODUCT_PHP}
 opnsense/suricata-devel				arm,arm64
 opnsense/syslogd
 ports-mgmt/pkg
+ports-mgmt/poudriere
 print/cups					arm,arm64
 print/texinfo
 security/${PRODUCT_CRYPTO}


### PR DESCRIPTION
While OPNsense deliberately builds only a small subset of packages from the ports tree, I read somewhere that users may request additional packages if those are not for extremely heavy-weight applications.

I'd like to see the ports builder **poudriere** being available as a package for OPNsense. Background for this is a [set of posts](https://forum.opnsense.org/index.php?topic=21739.0) that I published on the forums about package building on OPNsense. I'd like to return to this topic and write a little more about it. It wouldn't hurt, though, to make the whole process a little bit easier for the user.

Since poudriere is not a port with a lot of dependencies, I guess it might qualify for being added. I hope that I made my change to the right file, though, as I'm not too familiar with the OPNsense build system.