### PR TITLE
Add facility to create src.txz to build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@
 STEPS=		audit arm base boot chroot clean clone compress confirm core \
 		distfiles download dvd fingerprint info kernel list make.conf \
 		nano packages plugins ports prefetch print rebase release \
-		rename rewind serial sign skim test update upload verify \
+		rename rewind serial sign skim src test update upload verify \
 		vga vm xtools
 SCRIPTS=	batch distribution hotfix nightly
 
@@ -124,7 +124,7 @@ audit plugins: ports
 core: plugins
 packages test: core
 dvd nano serial vga vm: kernel core
-sets: kernel distfiles packages
+sets: kernel distfiles packages src
 images: dvd nano serial vga vm
 release: dvd nano serial vga
 

--- a/build/src.sh
+++ b/build/src.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# Copyright (c) 2014-2020 Franco Fichtner <franco@opnsense.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+
+set -e
+
+SELF=src
+
+. ./common.sh
+
+SRC_SET=$(find ${SETSDIR} -name "src-*-${PRODUCT_ARCH}${PRODUCT_DEVICE+"-${PRODUCT_DEVICE}"}.txz")
+
+if [ -f "${SRC_SET}" -a -z "${1}" ]; then
+	echo ">>> Reusing source set: ${SRC_SET}"
+	exit 0
+fi
+
+git_branch ${SRCDIR} ${SRCBRANCH} SRCBRANCH
+git_describe ${SRCDIR}
+
+${ENV_FILTER} make -s -C${SRCDIR}/release src.txz ${MAKE_ARGS}
+
+SRC_SET=${SETSDIR}/src-${REPO_VERSION}-${PRODUCT_ARCH}${PRODUCT_DEVICE+"-${PRODUCT_DEVICE}"}.txz
+
+cp  /usr/obj/usr/src/${PRODUCT_ARCH}.${PRODUCT_ARCH}/release/src.txz ${SRC_SET}
+generate_signature ${SRC_SET}


### PR DESCRIPTION
Due to the lack of the source distribution set, it is currently harder for people to build custom packages for their OPNsense installations than it has to be. Ideally the upcoming release could officially distribute src.txz.

This PR adds a simple script (basically base.sh modified accordingly). It also changes the Makefile to recognize the `src` target and add that as a dependency for `sets`. It's very simplistic (e.g. does no clean-up) as I didn't feel too confident with the build system.

I can try to make additional changes if requested, but it would probably easier if somebody actually familiar with the scripts would either do it or give me some hints on what to do.