### PR TITLE
Makefile: add $ROOTDIR support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,9 @@ lint: lint-steps lint-composite
 
 # Special vars to load early build.conf settings:
 
-TOOLSDIR?=	/usr/tools
+ROOTDIR?=	/usr
+
+TOOLSDIR?=	${ROOTDIR}/tools
 TOOLSBRANCH?=	master
 
 .if defined(CONFIGDIR)
@@ -104,23 +106,23 @@ EXTRABRANCH?=	# empty
 
 
 COREBRANCH?=	stable/${ABI}
-COREDIR?=	/usr/core
+COREDIR?=	${ROOTDIR}/core
 COREENV?=	CORE_PHP=${PHP} CORE_ABI=${ABI} CORE_PYTHON=${PYTHON}
 
 PLUGINSBRANCH?=	stable/${ABI}
-PLUGINSDIR?=	/usr/plugins
+PLUGINSDIR?=	${ROOTDIR}/plugins
 PLUGINSENV?=	PLUGIN_PHP=${PHP} PLUGIN_ABI=${ABI} PLUGIN_PYTHON=${PYTHON}
 
 PORTSBRANCH?=	master
-PORTSDIR?=	/usr/ports
+PORTSDIR?=	${ROOTDIR}/ports
 PORTSENV?=	# empty
 
 PORTSREFURL?=	https://git.FreeBSD.org/ports.git
-PORTSREFDIR?=	/usr/freebsd-ports
+PORTSREFDIR?=	${ROOTDIR}/freebsd-ports
 PORTSREFBRANCH?=main
 
 SRCBRANCH?=	stable/${ABI}
-SRCDIR?=	/usr/src
+SRCDIR?=	${ROOTDIR}/src
 
 # A couple of meta-targets for easy use and ordering:
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ All tasks require a root user.  Do the following to grab the repositories
     # cd tools
     # make update
 
+Note that the OPNsense repositories can also be setup in a non-/usr directory
+by setting ROOTDIR.  For example:
+
+    # mkdir -p /tmp/opnsense
+	# cd /tmp/opnsense
+	# git clone https://github.com/opnsense/tools
+	# cd tools
+	# env ROOTDIR=/tmp/opnsense make update
+
 TL;DR
 =====
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Note that the OPNsense repositories can also be setup in a non-/usr directory
 by setting ROOTDIR.  For example:
 
     # mkdir -p /tmp/opnsense
-	# cd /tmp/opnsense
-	# git clone https://github.com/opnsense/tools
-	# cd tools
-	# env ROOTDIR=/tmp/opnsense make update
+    # cd /tmp/opnsense
+    # git clone https://github.com/opnsense/tools
+    # cd tools
+    # env ROOTDIR=/tmp/opnsense make update
 
 TL;DR
 =====


### PR DESCRIPTION
This allows one to place the OPNsense repositories in a different
location, e.g., /root/opnsense, rather than reusing the host's /usr.