### PR TITLE
kernel: drop cross-build conditional for building kernel-toolchain

### DIFF
--- a/build/kernel.sh
+++ b/build/kernel.sh
@@ -58,9 +58,7 @@ __MAKE_CONF=
 ${MAKE_ARGS_DEV}
 "
 
-if [ ${PRODUCT_HOST} != ${PRODUCT_ARCH} ]; then
-	${ENV_FILTER} make -s -C${SRCDIR} -j${CPUS} kernel-toolchain ${MAKE_ARGS}
-fi
+${ENV_FILTER} make -s -C${SRCDIR} -j${CPUS} kernel-toolchain ${MAKE_ARGS}
 ${ENV_FILTER} make -s -C${SRCDIR} -j${CPUS} buildkernel ${MAKE_ARGS} NO_KERNELCLEAN=yes
 ${ENV_FILTER} make -s -C${SRCDIR}/release obj ${MAKE_ARGS}
 


### PR DESCRIPTION
It's actually non-trivial to determine if you need to build the
kernel-toolchain or not -- host version not matching the target exactly
is a valid reason, among others.

Unconditionally build kernel-toolchain to err on the side of caution and
towards prevention of confusing build failures.  If the `base` target
has already been built then no building really happens here, we simply
walk through all of the bootstrap tools and determine they're all up to
date.