### PR TITLE
device: cross-build is not always needed

### DIFF
--- a/device/ARM64.conf
+++ b/device/ARM64.conf
@@ -8,7 +8,9 @@ CROSS_BINUTILS_PREFIX=/usr/local/aarch64-unknown-freebsd${SRCREVISION}/bin
 export PRODUCT_KERNEL=SMP-ARM
 export PRODUCT_TARGET=arm64
 export PRODUCT_ARCH=aarch64
-export PRODUCT_WANTS="aarch64-binutils qemu-user-static"
+if [ "$PRODUCT_ARCH" != "$PRODUCT_HOST" ]; then
+    export PRODUCT_WANTS="aarch64-binutils qemu-user-static"
+fi
 
 # unset this for generic device handling, i.e. no device suffix
 unset PRODUCT_DEVICE

--- a/device/BANANAPI.conf
+++ b/device/BANANAPI.conf
@@ -10,7 +10,10 @@ UBLDR_LOADADDR=0x42000000
 export PRODUCT_KERNEL=SMP-ARM
 export PRODUCT_TARGET=arm
 export PRODUCT_ARCH=armv7
-export PRODUCT_WANTS="arm-none-eabi-binutils qemu-user-static u-boot-bananapi"
+export PRODUCT_WANTS="u-boot-bananapi"
+if [ "$PRODUCT_ARCH" != "$PRODUCT_HOST" ]; then
+	export PRODUCT_WANTS="${PRODUCT_WANTS} arm-none-eabi-binutils qemu-user-static"
+fi
 
 export ARM_UBOOT_DIR="/usr/local/share/u-boot/u-boot-bananapi"
 

--- a/device/CLEARFOG.conf
+++ b/device/CLEARFOG.conf
@@ -8,7 +8,10 @@ UBLDR_LOADADDR=0x900000
 export PRODUCT_KERNEL=SMP-ARM
 export PRODUCT_TARGET=arm
 export PRODUCT_ARCH=armv7
-export PRODUCT_WANTS="arm-none-eabi-binutils qemu-user-static u-boot-clearfog"
+export PRODUCT_WANTS="u-boot-clearfog"
+if [ "$PRODUCT_ARCH" != "$PRODUCT_HOST" ]; then
+    export PRODUCT_WANTS="${PRODUCT_WANTS} arm-none-eabi-binutils qemu-user-static"
+fi
 
 export ARM_UBOOT_DIR="/usr/local/share/u-boot/u-boot-clearfog"
 

--- a/device/RPI2.conf
+++ b/device/RPI2.conf
@@ -8,7 +8,10 @@ UBLDR_LOADADDR=0x2000000
 export PRODUCT_KERNEL=SMP-ARM
 export PRODUCT_TARGET=arm
 export PRODUCT_ARCH=armv7
-export PRODUCT_WANTS="arm-none-eabi-binutils qemu-user-static rpi-firmware u-boot-rpi2"
+export PRODUCT_WANTS="rpi-firmware u-boot-rpi2"
+if [ "$PRODUCT_ARCH" != "$PRODUCT_HOST" ]; then
+    export PRODUCT_WANTS="${PRODUCT_WANTS} arm-none-eabi-binutils qemu-user-static"
+fi
 
 export ARM_FIRMWARE_DIR="/usr/local/share/rpi-firmware"
 export ARM_UBOOT_DIR="/usr/local/share/u-boot/u-boot-rpi2"

--- a/device/RPI3.conf
+++ b/device/RPI3.conf
@@ -9,7 +9,10 @@ UBLDR_LOADADDR=0x42000000
 export PRODUCT_KERNEL=SMP-ARM
 export PRODUCT_TARGET=arm64
 export PRODUCT_ARCH=aarch64
-export PRODUCT_WANTS="aarch64-binutils qemu-user-static u-boot-rpi3 rpi-firmware"
+export PRODUCT_WANTS="u-boot-rpi3 rpi-firmware"
+if [ "$PRODUCT_ARCH" != "$PRODUCT_HOST" ]; then
+	export PRODUCT_WANTS="${PRODUCT_WANTS} aarch64-binutils qemu-user-static"
+fi
 
 export ARM_FIRMWARE_DIR="/usr/local/share/rpi-firmware"
 export ARM_UBOOT_DIR="/usr/local/share/u-boot/u-boot-rpi3"


### PR DESCRIPTION
cross-building is not needed when building aarch64 target on aarch64 host.