### PR TITLE
enable RPI4 support for 22.1

### DIFF
--- a/device/RPI.conf
+++ b/device/RPI.conf
@@ -23,7 +23,8 @@ arm_install_uboot()
 	cp -p ${ARM_FIRMWARE_DIR}/bcm2710-rpi-3-b*.dtb ${STAGEDIR}/boot/msdos
 	cp -p ${ARM_FIRMWARE_DIR}/bcm2711-rpi-4-b.dtb ${STAGEDIR}/boot/msdos
 	cp -p ${ARM_FIRMWARE_DIR}/bootcode.bin ${STAGEDIR}/boot/msdos
-	cp -p ${ARM_FIRMWARE_DIR}/config*.txt ${STAGEDIR}/boot/msdos
+	cp -p ${ARM_FIRMWARE_DIR}/config_rpi3.txt ${STAGEDIR}/boot/msdos
+	cp -p ${ARM_FIRMWARE_DIR}/config_rpi4.txt ${STAGEDIR}/boot/msdos
 	cp -p ${ARM_FIRMWARE_DIR}/fixup*.dat ${STAGEDIR}/boot/msdos
 	cp -p ${ARM_FIRMWARE_DIR}/start*.elf ${STAGEDIR}/boot/msdos
 	cp -pr ${ARM_FIRMWARE_DIR}/overlays ${STAGEDIR}/boot/msdos/overlays

--- a/device/RPI.conf
+++ b/device/RPI.conf
@@ -3,6 +3,7 @@
 # https://www.raspberrypi.com/products/raspberry-pi-4-model-b/
 
 export MAKE_ARGS_DEV="
+CROSS_BINUTILS_PREFIX=/usr/local/aarch64-unknown-freebsd${SRCREVISION}/bin
 UBLDR_LOADADDR=0x42000000
 WITHOUT_MODULES=cloudabi32
 "

--- a/device/RPI.conf
+++ b/device/RPI.conf
@@ -1,8 +1,8 @@
 # https://www.raspberrypi.org/products/raspberry-pi-3-model-b/
 # https://www.raspberrypi.org/products/raspberry-pi-3-model-b-plus/
+# https://www.raspberrypi.com/products/raspberry-pi-4-model-b/
 
 export MAKE_ARGS_DEV="
-CROSS_BINUTILS_PREFIX=/usr/local/aarch64-unknown-freebsd${SRCREVISION}/bin
 UBLDR_LOADADDR=0x42000000
 WITHOUT_MODULES=cloudabi32
 "
@@ -10,25 +10,24 @@ WITHOUT_MODULES=cloudabi32
 export PRODUCT_KERNEL=SMP-ARM
 export PRODUCT_TARGET=arm64
 export PRODUCT_ARCH=aarch64
-export PRODUCT_WANTS="u-boot-rpi3 rpi-firmware"
+export PRODUCT_WANTS="u-boot-rpi4 rpi-firmware"
 export PRODUCT_WANTS_CROSS="aarch64-binutils qemu-user-static"
 
 export ARM_FIRMWARE_DIR="/usr/local/share/rpi-firmware"
-export ARM_UBOOT_DIR="/usr/local/share/u-boot/u-boot-rpi3"
+export ARM_UBOOT_DIR="/usr/local/share/u-boot/u-boot-rpi4"
 
 arm_install_uboot()
 {
-	cp -p ${ARM_UBOOT_DIR}/README ${STAGEDIR}/boot/msdos
-	cp -p ${ARM_UBOOT_DIR}/u-boot.bin ${STAGEDIR}/boot/msdos
-	cp -p ${ARM_FIRMWARE_DIR}/armstub8*.bin ${STAGEDIR}/boot/msdos
-	cp -p ${ARM_FIRMWARE_DIR}/bootcode.bin ${STAGEDIR}/boot/msdos
-	cp -p ${ARM_FIRMWARE_DIR}/fixup* ${STAGEDIR}/boot/msdos
 	cp -p ${ARM_FIRMWARE_DIR}/LICENCE.broadcom ${STAGEDIR}/boot/msdos
-	cp -p ${ARM_FIRMWARE_DIR}/start* ${STAGEDIR}/boot/msdos
-	cp -p ${ARM_FIRMWARE_DIR}/config*.txt ${STAGEDIR}/boot/msdos
+	cp -p ${ARM_FIRMWARE_DIR}/armstub8*.bin ${STAGEDIR}/boot/msdos
 	cp -p ${ARM_FIRMWARE_DIR}/bcm2710-rpi-3-b*.dtb ${STAGEDIR}/boot/msdos
-	cp -p ${ARM_FIRMWARE_DIR}/bcm2711-rpi-4*.dtb ${STAGEDIR}/boot/msdos
-	cp -p ${ARM_FIRMWARE_DIR}/bcm271*-rpi-cm*.dtb ${STAGEDIR}/boot/msdos
+	cp -p ${ARM_FIRMWARE_DIR}/bcm2711-rpi-4-b.dtb ${STAGEDIR}/boot/msdos
+	cp -p ${ARM_FIRMWARE_DIR}/bootcode.bin ${STAGEDIR}/boot/msdos
+	cp -p ${ARM_FIRMWARE_DIR}/config*.txt ${STAGEDIR}/boot/msdos
+	cp -p ${ARM_FIRMWARE_DIR}/fixup*.dat ${STAGEDIR}/boot/msdos
+	cp -p ${ARM_FIRMWARE_DIR}/start*.elf ${STAGEDIR}/boot/msdos
 	cp -pr ${ARM_FIRMWARE_DIR}/overlays ${STAGEDIR}/boot/msdos/overlays
 	cp -pr ${STAGEDIR}/boot/dtb ${STAGEDIR}/boot/msdos/dtb
+	cp -p ${ARM_UBOOT_DIR}/README ${STAGEDIR}/boot/msdos
+	cp -p ${ARM_UBOOT_DIR}/u-boot.bin ${STAGEDIR}/boot/msdos
 }


### PR DESCRIPTION
RPI3 and RPI4 are combined together as in FreeBSD 13 builds.

![Screen Shot 2022-02-10 at 2 45 29 PM](https://user-images.githubusercontent.com/8390472/153354949-f18d97d7-2709-479e-b721-af45a9acbd73.png)

