### PR TITLE
build/arm.sh: resize ARMSIZE to 2G

### DIFF
--- a/build/arm.sh
+++ b/build/arm.sh
@@ -39,7 +39,7 @@ fi
 
 check_image ${SELF} ${@}
 
-ARMSIZE="3G"
+ARMSIZE="2G"
 
 if [ -n "${1}" ]; then
 	ARMSIZE=${1}


### PR DESCRIPTION
2G is enough as it takes about 1.8G in total.
Reduced size could help to save time in image-making, compressing, downloading, and disk writing.