### PR TITLE
add check_mk_agent

### DIFF
--- a/config/22.1/ports.conf
+++ b/config/22.1/ports.conf
@@ -96,6 +96,7 @@ net-mgmt/nrpe3					arm
 net-mgmt/py-opn-cli
 net-mgmt/telegraf				arm
 net-mgmt/yaf					arm
+net-mgmt/check_mk_agent
 net-mgmt/zabbix4-proxy				arm
 net-mgmt/zabbix5-agent				arm
 net-mgmt/zabbix5-proxy				arm


### PR DESCRIPTION
check-mk-agent is needed by check-mk for monitoring freebsd instances.