### PR TITLE
Fix build failure during arm_install_uboot() on RockPro64

### DIFF
--- a/device/ROCKPRO64.conf
+++ b/device/ROCKPRO64.conf
@@ -19,7 +19,9 @@ export ARM_UBOOT_DIR="/usr/local/share/u-boot/u-boot-rockpro64"
 
 arm_install_uboot()
 {
+        sysctl kern.geom.debugflags=0x10
         dd if=${ARM_UBOOT_DIR}/idbloader.img of=/dev/${DEV} seek=64 bs=512 conv=sync
         dd if=${ARM_UBOOT_DIR}/u-boot.itb of=/dev/${DEV} seek=16384 bs=512 conv=sync
         cp -pr ${STAGEDIR}/boot/dtb ${STAGEDIR}/boot/msdos
+        sysctl kern.geom.debugflags=0x0
 }


### PR DESCRIPTION
Build would fail when writing to the image's MSDOSBOOT partition without 'sysctl kern.geom.debugflags=0x10'