### PR TITLE
distfiles target needs SRCDIR when ROOTDIR is not /usr/src

### DIFF
--- a/build/distfiles.sh
+++ b/build/distfiles.sh
@@ -65,12 +65,12 @@ USE_PACKAGE_DEPENDS=yes
 "
 	echo ">>> Fetching \${PORT_ORIGIN}..."
 	PORT=\${PORT_ORIGIN%%@*}
-	make -C ${PORTSDIR}/\${PORT} fetch \${MAKE_ARGS}
-	PORT_DEPENDS=\$(make -C ${PORTSDIR}/\${PORT} all-depends-list \
+	make SRC_BASE=${SRCDIR} -C ${PORTSDIR}/\${PORT} fetch \${MAKE_ARGS}
+	PORT_DEPENDS=\$(make SRC_BASE=${SRCDIR} -C ${PORTSDIR}/\${PORT} all-depends-list \
 	    \${MAKE_ARGS})
 	for PORT_DEPEND in \${PORT_DEPENDS}; do
 		PORT_DEPEND=\${PORT_DEPEND%%@*}
-		make -C \${PORT_DEPEND} fetch \${MAKE_ARGS}
+		make SRC_BASE=${SRCDIR} -C \${PORT_DEPEND} fetch \${MAKE_ARGS}
 	done
 done
 EOF


### PR DESCRIPTION
Some ports need kernel sources, the source directory can be passed
in through SRC_BASE to the ports makefile. When ROORDIR is anything
but /usr/src this is needed for the distfiles target. Pass it in when the
package makefile runs.