### PR TITLE
Fix aarch64 build

### DIFF
--- a/config/22.7/plugins.conf
+++ b/config/22.7/plugins.conf
@@ -75,8 +75,8 @@ sysutils/hw-probe				arm
 sysutils/lcdproc-sdeclcd			arm,aarch64
 sysutils/munin-node				arm
 sysutils/nextcloud-backup
-sysutils/node_exporter				arm
-sysutils/nut					arm
+sysutils/node_exporter				arm,aarch64
+sysutils/nut					arm,aarch64
 sysutils/puppet-agent				arm
 sysutils/smart					arm
 sysutils/virtualbox				arm,aarch64

--- a/config/22.7/ports.conf
+++ b/config/22.7/ports.conf
@@ -221,8 +221,8 @@ sysutils/monit
 sysutils/msktutil				arm
 sysutils/multitail				arm
 sysutils/munin-node				arm
-sysutils/node_exporter				arm
-sysutils/nut					arm
+sysutils/node_exporter				arm,aarch64
+sysutils/nut					arm,aarch64
 sysutils/pftop
 sysutils/puppet7				arm
 sysutils/screen


### PR DESCRIPTION
Fixes build on aarch64 by disable node_exporter and nut. Building
these packages would fail due to freeipmi unavailability.

Fixes: #303