### PR TITLE
Allow building Arm images without cross compilation

### DIFF
--- a/device/ARM64.conf
+++ b/device/ARM64.conf
@@ -8,7 +8,12 @@ WITHOUT_MODULES=cloudabi32
 export PRODUCT_KERNEL=SMP-ARM
 export PRODUCT_TARGET=arm64
 export PRODUCT_ARCH=aarch64
-export PRODUCT_WANTS_CROSS="aarch64-binutils qemu-user-static"
+export PRODUCT_WANTS_CROSS=$(if [ ${PRODUCT_HOST} != ${PRODUCT_ARCH} ]; then
+                                 echo -n "aarch64-binutils qemu-user-static"
+                             else
+                                 echo -n "aarch64-binutils"
+                             fi
+                            )
 
 # unset this for generic device handling, i.e. no device suffix
 unset PRODUCT_DEVICE

--- a/device/RPI.conf
+++ b/device/RPI.conf
@@ -11,7 +11,12 @@ export PRODUCT_KERNEL=SMP-ARM
 export PRODUCT_TARGET=arm64
 export PRODUCT_ARCH=aarch64
 export PRODUCT_WANTS="u-boot-rpi4 rpi-firmware"
-export PRODUCT_WANTS_CROSS="aarch64-binutils qemu-user-static"
+export PRODUCT_WANTS_CROSS=$(if [ ${PRODUCT_HOST} != ${PRODUCT_ARCH} ]; then
+                                 echo -n "aarch64-binutils qemu-user-static"
+                             else
+                                 echo -n "aarch64-binutils"
+                             fi
+                            )
 
 export ARM_FIRMWARE_DIR="/usr/local/share/rpi-firmware"
 export ARM_UBOOT_DIR="/usr/local/share/u-boot/u-boot-rpi4"


### PR DESCRIPTION
qemu-user-static is as of now not available on Freebsd13.1 aarch64 and it is not needed, because you do not need to cross compile in this case. Without this change you would need to modify RPI.conf by hand.