### PR TITLE
build: Allow delimiters other than newline in {AUX,PLUGINS,PORTS}LIST

### DIFF
--- a/build/audit.sh
+++ b/build/audit.sh
@@ -31,9 +31,7 @@ SELF=audit
 
 . ./common.sh
 
-if [ -z "${PORTSLIST}" ]; then
-	PORTSLIST=$(list_packages ${CONFIGDIR}/ports.conf)
-fi
+PORTSLIST=$(list_packages "${PORTSLIST}" ${CONFIGDIR}/ports.conf)
 
 setup_stage ${STAGEDIR}
 setup_base ${STAGEDIR}

--- a/build/common.sh
+++ b/build/common.sh
@@ -1233,5 +1233,10 @@ list_packages()
 {
 	local LIST_MATCH=1
 
-	list_config ${@}
+	if [ -n "${1}" ]; then
+		echo "${1}" | tr ',[:blank:]' '\n'
+	else
+		shift
+		list_config ${@}
+	fi
 }

--- a/build/distfiles.sh
+++ b/build/distfiles.sh
@@ -31,9 +31,7 @@ SELF=distfiles
 
 . ./common.sh
 
-if [ -z "${PORTSLIST}" ]; then
-	PORTSLIST=$(list_packages ${CONFIGDIR}/aux.conf ${CONFIGDIR}/ports.conf)
-fi
+PORTSLIST=$(list_packages "${PORTSLIST}" ${CONFIGDIR}/aux.conf ${CONFIGDIR}/ports.conf)
 
 git_branch ${SRCDIR} ${SRCBRANCH} SRCBRANCH
 git_branch ${PORTSDIR} ${PORTSBRANCH} PORTSBRANCH

--- a/build/options.sh
+++ b/build/options.sh
@@ -31,9 +31,7 @@ SELF=options
 
 . ./common.sh
 
-if [ -z "${PORTSLIST}" ]; then
-	PORTSLIST=$(list_packages ${CONFIGDIR}/aux.conf ${CONFIGDIR}/ports.conf)
-fi
+PORTSLIST=$(list_packages "${PORTSLIST}" ${CONFIGDIR}/aux.conf ${CONFIGDIR}/ports.conf)
 
 git_branch ${SRCDIR} ${SRCBRANCH} SRCBRANCH
 git_branch ${PORTSDIR} ${PORTSBRANCH} PORTSBRANCH

--- a/build/plugins.sh
+++ b/build/plugins.sh
@@ -36,15 +36,13 @@ if check_packages ${SELF} ${@}; then
 	exit 0
 fi
 
-if [ -z "${PLUGINSLIST}" ]; then
-	PLUGINSCONF=${CONFIGDIR}/plugins.conf
+PLUGINSCONF=${CONFIGDIR}/plugins.conf
 
-	if [ -f ${PLUGINSCONF}.local ]; then
-		PLUGINSCONF="${PLUGINSCONF} ${PLUGINSCONF}.local"
-	fi
-
-	PLUGINSLIST=$(list_packages ${PLUGINSCONF})
+if [ -f ${PLUGINSCONF}.local ]; then
+	PLUGINSCONF="${PLUGINSCONF} ${PLUGINSCONF}.local"
 fi
+
+PLUGINSLIST=$(list_packages "${PLUGINSLIST}" ${PLUGINSCONF})
 
 git_branch ${PLUGINSDIR} ${PLUGINSBRANCH} PLUGINSBRANCH
 

--- a/build/ports.sh
+++ b/build/ports.sh
@@ -56,12 +56,8 @@ if check_packages ${SELF} ${ARGS}; then
 	exit 0
 fi
 
-if [ -z "${PORTSLIST}" ]; then
-	PORTSLIST=$(list_packages ${CONFIGDIR}/ports.conf)
-fi
-if [ -z "${AUXLIST}" ]; then
-	AUXLIST=$(list_packages ${CONFIGDIR}/aux.conf)
-fi
+PORTSLIST=$(list_packages "${PORTSLIST}" ${CONFIGDIR}/ports.conf)
+AUXLIST=$(list_packages "${AUXLIST}" ${CONFIGDIR}/aux.conf)
 
 git_branch ${SRCDIR} ${SRCBRANCH} SRCBRANCH
 git_branch ${PORTSDIR} ${PORTSBRANCH} PORTSBRANCH

--- a/build/test.sh
+++ b/build/test.sh
@@ -58,15 +58,13 @@ make -C${COREDIR} ${COREENV} style
 make -C${COREDIR} ${COREENV} test
 EOF
 
-if [ -z "${PLUGINSLIST}" ]; then
-	PLUGINSCONF=${CONFIGDIR}/plugins.conf
+PLUGINSCONF=${CONFIGDIR}/plugins.conf
 
-	if [ -f ${PLUGINSCONF}.local ]; then
-		PLUGINSCONF="${PLUGINSCONF} ${PLUGINSCONF}.local"
-	fi
-
-	PLUGINSLIST=$(list_packages ${PLUGINSCONF})
+if [ -f ${PLUGINSCONF}.local ]; then
+	PLUGINSCONF="${PLUGINSCONF} ${PLUGINSCONF}.local"
 fi
+
+PLUGINSLIST=$(list_packages "${PLUGINSLIST}" ${PLUGINSCONF})
 
 for PLUGIN_ORIGIN in ${PLUGINSLIST}; do
 	VARIANT=${PLUGIN_ORIGIN##*@}


### PR DESCRIPTION
Currently, when assigning multiple items to a LIST, the following works:
```
make ports PORTSLIST="port/a
port/b"
```
while the following would fail:
```
make ports PORTSLIST="port/a port/b"
```

This patch makes comma, space and tab acceptable as delimiters instead of newline only.