### PR TITLE
replace qemu-guest-agent with new qemu guestagent FLAVOR

### DIFF
--- a/config/23.1/ports.conf
+++ b/config/23.1/ports.conf
@@ -59,7 +59,7 @@ editors/joe
 editors/nano
 editors/vim
 emulators/open-vm-tools-nox11			arm,aarch64
-emulators/qemu-guest-agent			arm
+emulators/qemu@guestagent			arm
 emulators/virtualbox-ose-additions-nox11	arm,aarch64
 ftp/curl
 ftp/php${PRODUCT_PHP}-curl


### PR DESCRIPTION
refs https://github.com/opnsense/plugins/issues/3283

@fichtner, the removed port `emulators/qemu-guest-agent` can probably be removed from the OPNsense ports tree when this was merged.