### PR TITLE
Enable secondary serial console for VM images

### DIFF
--- a/config/23.7/extras.conf
+++ b/config/23.7/extras.conf
@@ -117,5 +117,22 @@ vm_hook()
 {
 	loader_conf_fixup ${1}
 
+	cat > ${1}/tmp/vm.xml << EOF
+    <serialspeed>${PRODUCT_COMSPEED}</serialspeed>
+    <primaryconsole>video</primaryconsole>
+    <secondaryconsole>serial</secondaryconsole>
+EOF
+	sed -i '' -e "/<system>/r ${1}/tmp/vm.xml" ${1}${CONFIG_XML}
+	rm ${1}/tmp/vm.xml
+
+	echo "-S${PRODUCT_COMSPEED} -h -D" > ${1}/boot.config
+
+	cat >> ${1}/boot/loader.conf << EOF
+comconsole_speed="${PRODUCT_COMSPEED}"
+console="vidconsole,comconsole"
+boot_multicons="YES"
+boot_serial="YES"
+EOF
+
 	touch ${1}/.probe.for.growfs
 }


### PR DESCRIPTION
Allow initial configuration / interface assignment of VMs in virtualisation environments without a video console.