### PR TITLE
Add devel/abseil and devel/re2

### DIFF
--- a/config/23.7/ports.conf
+++ b/config/23.7/ports.conf
@@ -19,6 +19,7 @@ databases/py-sqlite3@py${PRODUCT_PYTHON}
 databases/pymongo				arm
 databases/redis					arm
 databases/rrdtool
+devel/abseil
 devel/arcanist@php${PRODUCT_PHP}		arm
 devel/automake
 devel/awscli					arm
@@ -44,6 +45,7 @@ devel/pkgconf
 devel/py-Jinja2@py${PRODUCT_PYTHON}
 devel/py-pycodestyle@py${PRODUCT_PYTHON}
 devel/py-ujson@py${PRODUCT_PYTHON}
+devel/re2
 devel/scons
 dns/bind-tools
 dns/bind918					arm


### PR DESCRIPTION
The libraries are now a required dependency for crowdsec v1.5.4, which has been released today and submitted to the upstream freebsd ports.