### PR TITLE
Publish the checksums (also) for the unpacked image files

### DIFF
--- a/build/compress.sh
+++ b/build/compress.sh
@@ -36,6 +36,9 @@ for ARG in ${@}; do
 	arm|dvd|nano|serial|vga|vm)
 		for IMAGE in $(find ${IMAGESDIR} -name \
 		    "*-${ARG}-*" \! -name "*.bz2" \! -name "*.sig"); do
+			echo -n ">>> Checksumming uncompressed image ${IMAGE} for ${PRODUCT_RELEASE}... "
+   			(cd ${IMAGESDIR} && sha256 ${IMAGE}) >> ${IMAGESDIR}/checksums
+	 		echo "done"
 			echo -n ">>> Compressing ${ARG} image... "
 			bzip2 ${IMAGE}
 			echo "done"

--- a/build/release.sh
+++ b/build/release.sh
@@ -57,9 +57,13 @@ for IMAGE in $(find ${IMAGESDIR} -name "${PRODUCT_NAME}-*-${PRODUCT_ARCH}.*.bz2"
 	cp ${IMAGE} ${STAGEDIR}
 done
 
-echo -n ">>> Checksumming images for ${PRODUCT_RELEASE}... "
+echo -n ">>> Checksumming compressed images for ${PRODUCT_RELEASE}... "
 
-(cd ${STAGEDIR} && sha256 ${PRODUCT_RELEASE}-*) > ${STAGEDIR}/checksums
+if [ -f "${IMAGESDIR}/checksums" ]; then
+	cp ${IMAGESDIR}/checksums ${STAGEDIR}/checksums
+fi
+
+(cd ${STAGEDIR} && sha256 ${PRODUCT_RELEASE}-*) >> ${STAGEDIR}/checksums
 mv ${STAGEDIR}/checksums \
     ${STAGEDIR}/${PRODUCT_RELEASE}-checksums-${PRODUCT_ARCH}.sha256
 


### PR DESCRIPTION
Rationale: You should be able to check the sanity of the unpacked image as well, in case you use some weird broken unpacking tool. Reference: https://forum.opnsense.org/index.php?topic=37074.0

**Note: This patch is completely untested, really do not have the time for testing ATM.**