### PR TITLE
config: ignore freeipmi on aarch64

### DIFF
--- a/config/23.7/ports.conf
+++ b/config/23.7/ports.conf
@@ -216,7 +216,7 @@ sysutils/dmidecode				arm
 sysutils/ethname
 sysutils/flashrom				arm,aarch64
 sysutils/flock
-sysutils/freeipmi				arm
+sysutils/freeipmi				arm,aarch64
 sysutils/hw-probe				arm
 sysutils/iohyve					arm
 sysutils/lcdproc				arm,aarch64


### PR DESCRIPTION
Was added in 1aae3368facf313f8bd601a1fc28092aa7fc4444, but is broken on aarch64:
https://svnweb.freebsd.org/ports?view=revision&revision=536924
https://www.freshports.org/sysutils/freeipmi