### PR TITLE
Update make.conf for caddy-custom build to mitigate build errors

### DIFF
--- a/config/24.1/make.conf
+++ b/config/24.1/make.conf
@@ -105,12 +105,15 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport \
 				github.com/caddy-dns/googleclouddns \
 				github.com/caddy-dns/gandi \
 				github.com/caddy-dns/azure \
-				github.com/caddy-dns/vultr \
+				github.com/caddy-dns/porkbun \
 				github.com/caddy-dns/openstack-designate \
 				github.com/caddy-dns/google-domains \
 				github.com/caddy-dns/ovh \
 				github.com/caddy-dns/namecheap \
+				github.com/caddy-dns/netlify \
 				github.com/caddy-dns/acmedns \
+				github.com/caddy-dns/desec \
+				github.com/caddy-dns/namesilo \
 				github.com/caddy-dns/powerdns \
 				github.com/caddy-dns/vercel \
 				github.com/caddy-dns/ddnss \
@@ -123,8 +126,4 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport \
 				github.com/caddy-dns/hexonet \
 				github.com/caddy-dns/mailinabox
 
-CADDY_CUSTOM_PLUGINS_BROKEN=	github.com/caddy-dns/netcup \
-				github.com/caddy-dns/desec \
-				github.com/caddy-dns/porkbun \
-				github.com/caddy-dns/netlify \
-				github.com/caddy-dns/namesilo
+CADDY_CUSTOM_PLUGINS_BROKEN=	github.com/caddy-dns/vultr

--- a/config/24.1/make.conf
+++ b/config/24.1/make.conf
@@ -125,5 +125,3 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport \
 				github.com/caddy-dns/ionos \
 				github.com/caddy-dns/hexonet \
 				github.com/caddy-dns/mailinabox
-
-CADDY_CUSTOM_PLUGINS_BROKEN=	github.com/caddy-dns/vultr


### PR DESCRIPTION
As explained here:
https://github.com/Monviech/os-caddy-plugin/issues/102

Change the build priority to `desec` and `porkbun` instead of `vultr`, since they have been especially requested in past issues of os-caddy-plugin.

The issue stems from `vultr` having different `libdns` dependencies than the other modules, making the build fail if it's included with certain other combinations of modules (e.g. `desec`).