### PR TITLE
www/caddy: caddy-custom build that includes all caddy-dns providers

### DIFF
--- a/config/24.1/make.conf
+++ b/config/24.1/make.conf
@@ -123,7 +123,7 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport \
 				github.com/caddy-dns/dinahosting \
 				github.com/caddy-dns/ionos \
 				github.com/caddy-dns/hexonet \
-				github.com/caddy-dns/mailinabox
+				github.com/caddy-dns/mailinabox \
 				github.com/caddy-dns/dnsmadeeasy \
 				github.com/caddy-dns/bunny \
 				github.com/caddy-dns/civo \

--- a/config/24.1/make.conf
+++ b/config/24.1/make.conf
@@ -107,7 +107,6 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport \
 				github.com/caddy-dns/azure \
 				github.com/caddy-dns/porkbun \
 				github.com/caddy-dns/openstack-designate \
-				github.com/caddy-dns/google-domains \
 				github.com/caddy-dns/ovh \
 				github.com/caddy-dns/namecheap \
 				github.com/caddy-dns/netlify \
@@ -125,3 +124,19 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport \
 				github.com/caddy-dns/ionos \
 				github.com/caddy-dns/hexonet \
 				github.com/caddy-dns/mailinabox
+				github.com/caddy-dns/dnsmadeeasy \
+				github.com/caddy-dns/bunny \
+				github.com/caddy-dns/civo \
+				github.com/caddy-dns/scaleway \
+				github.com/caddy-dns/acmeproxy \
+				github.com/caddy-dns/inwx \
+				github.com/caddy-dns/namedotcom \
+				github.com/caddy-dns/easydns \
+				github.com/caddy-dns/infomaniak \
+				github.com/caddy-dns/directadmin \
+				github.com/caddy-dns/hosttech \
+				github.com/caddy-dns/rfc2136 \
+				github.com/caddy-dns/loopia \
+				github.com/caddy-dns/mythicbeasts \
+				github.com/caddy-dns/glesys \
+				github.com/caddy-dns/dynv6


### PR DESCRIPTION
Needed for: https://github.com/opnsense/plugins/pull/3851

The build checks out with xcaddy without any errors.

github.com/caddy-dns/google-domains has been removed because it's unmaintained.