### PR TITLE
www/caddy-custom: Make current build reproducible

### DIFF
--- a/config/24.1/make.conf
+++ b/config/24.1/make.conf
@@ -92,7 +92,6 @@ www_squid_UNSET=		AUTH_NIS TP_IPFW
 www_webgrind_SET=		CALLGRAPH
 
 # for www/caddy-custom
-CADDY_CUSTOM_VERSION=		v2.7.6
 CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d06a83964da5573ee6a51f \
 				github.com/mholt/caddy-dynamicdns@7848511af7a4cfba383d911c3f9b2f73d2c3f3cb \
 				github.com/caddy-dns/cloudflare@2fa0c8ac916ab13ee14c836e59fec9d85857e429 \

--- a/config/24.1/make.conf
+++ b/config/24.1/make.conf
@@ -92,6 +92,7 @@ www_squid_UNSET=		AUTH_NIS TP_IPFW
 www_webgrind_SET=		CALLGRAPH
 
 # for www/caddy-custom
+CADDY_CUSTOM_VERSION=		v2.7.6
 CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d06a83964da5573ee6a51f \
 				github.com/mholt/caddy-dynamicdns@7848511af7a4cfba383d911c3f9b2f73d2c3f3cb \
 				github.com/caddy-dns/cloudflare@2fa0c8ac916ab13ee14c836e59fec9d85857e429 \

--- a/config/24.1/make.conf
+++ b/config/24.1/make.conf
@@ -92,36 +92,35 @@ www_squid_UNSET=		AUTH_NIS TP_IPFW
 www_webgrind_SET=		CALLGRAPH
 
 # for www/caddy-custom
-CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport \
-				github.com/mholt/caddy-dynamicdns \
+CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d06a83964da5573ee6a51f \
+				github.com/mholt/caddy-dynamicdns@7848511af7a4cfba383d911c3f9b2f73d2c3f3cb \
 				github.com/caddy-dns/cloudflare@2fa0c8ac916ab13ee14c836e59fec9d85857e429 \
-				github.com/caddy-dns/route53 \
-				github.com/caddy-dns/duckdns \
-				github.com/caddy-dns/digitalocean \
-				github.com/caddy-dns/dnspod \
-				github.com/caddy-dns/alidns \
-				github.com/caddy-dns/hetzner \
-				github.com/caddy-dns/godaddy \
-				github.com/caddy-dns/googleclouddns \
-				github.com/caddy-dns/gandi \
-				github.com/caddy-dns/azure \
-				github.com/caddy-dns/porkbun \
-				github.com/caddy-dns/openstack-designate \
-				github.com/caddy-dns/google-domains \
-				github.com/caddy-dns/ovh \
-				github.com/caddy-dns/namecheap \
-				github.com/caddy-dns/netlify \
-				github.com/caddy-dns/acmedns \
-				github.com/caddy-dns/desec \
-				github.com/caddy-dns/namesilo \
-				github.com/caddy-dns/powerdns \
-				github.com/caddy-dns/vercel \
-				github.com/caddy-dns/ddnss \
-				github.com/caddy-dns/njalla \
-				github.com/caddy-dns/metaname \
-				github.com/caddy-dns/linode \
-				github.com/caddy-dns/tencentcloud \
-				github.com/caddy-dns/dinahosting \
-				github.com/caddy-dns/ionos \
-				github.com/caddy-dns/hexonet \
-				github.com/caddy-dns/mailinabox
+				github.com/caddy-dns/route53@8e49e7546771bf6846e1531dcaff4925af5ddcde \
+				github.com/caddy-dns/duckdns@77870e12bac552ceb76917d82ced6db84b958c1f \
+				github.com/caddy-dns/digitalocean@9c71e343246b954976c9294a7062823605de9b9f \
+				github.com/caddy-dns/dnspod@1fd4ce87e919f47db5fa029c31ae74b9737a58af \
+				github.com/caddy-dns/alidns@fa0c17aaf72a7ba4d3ce564cffb62a0f80c01ab3 \
+				github.com/caddy-dns/hetzner@470ff7c91fc48797a37b475bf6ddaf02700bc02c \
+				github.com/caddy-dns/godaddy@7634a752ba5bda3977b461c60f5936eba3d02426 \
+				github.com/caddy-dns/googleclouddns@22c91a4de6d3c3a17d395e510e1b77eab82cdc3c \
+				github.com/caddy-dns/gandi@34327df7b24751de1b67e4b23b618c091aaeeff8 \
+				github.com/caddy-dns/azure@f2351591d9f258201499abc37d054b7e6366fefb \
+				github.com/caddy-dns/porkbun@4267f6797bf6543d7b20cdc8578a31764face4cf \
+				github.com/caddy-dns/openstack-designate@3d04840644828859aacf731311c96004750e3bab \
+				github.com/caddy-dns/ovh@f71a5c6fd0073f94dd24e49233775d9b087dfe5d \
+				github.com/caddy-dns/namecheap@7095083a353829fc83632c34e8988fd8eb72f43d \
+				github.com/caddy-dns/netlify@575e1c71321efc4e9c34576e6942adb06b529a75 \
+				github.com/caddy-dns/acmedns@18621dd3e69e048eae80c4171ef56cb576dce2f4 \
+				github.com/caddy-dns/desec@e1e64971fe34c29ce3f4176464adb84d6890aa50 \
+				github.com/caddy-dns/namesilo@1c65d36b415456ee474ae64ebe46f13def3e18a6 \
+				github.com/caddy-dns/powerdns@79c99dcd21421184998486265ad3242f79b8bda6 \
+				github.com/caddy-dns/vercel@ac196e3e1b5ef24869868b744548da320318137f \
+				github.com/caddy-dns/ddnss@7f65108b0a6249d8e630fe2431143069c4317ee4 \
+				github.com/caddy-dns/njalla@57869f89026a2e8980d1b3fac5687e115e9acb36 \
+				github.com/caddy-dns/metaname@7a6129725322cbc7808e3697989560299d190aaf \
+				github.com/caddy-dns/linode@6fa218b5e8d6495dd96359b5550937f10234b360 \
+				github.com/caddy-dns/tencentcloud@d0f5c8c8114232a2c04f6912fb5de54d02e58245 \
+				github.com/caddy-dns/dinahosting@38b1acca4e37dac795cdd2ec239acb4fc3df7fef \
+				github.com/caddy-dns/ionos@751e8e24162290ee74bea465ae733a2bf49551a6 \
+				github.com/caddy-dns/hexonet@2df0595f17b1cae63394c9488eec55f4c1b63650 \
+				github.com/caddy-dns/mailinabox@46af20439f1f0b8e7fdd65c2069b77d3c2c96ef1

--- a/config/24.1/make.conf
+++ b/config/24.1/make.conf
@@ -94,7 +94,7 @@ www_webgrind_SET=		CALLGRAPH
 # for www/caddy-custom
 CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport \
 				github.com/mholt/caddy-dynamicdns \
-				github.com/caddy-dns/cloudflare \
+				github.com/caddy-dns/cloudflare@2fa0c8ac916ab13ee14c836e59fec9d85857e429 \
 				github.com/caddy-dns/route53 \
 				github.com/caddy-dns/duckdns \
 				github.com/caddy-dns/digitalocean \


### PR DESCRIPTION
Requires: https://github.com/opnsense/ports/pull/190

Lock the whole build down with commit hashes and version tag. Upstream changes won't make the build fail all of a sudden now (or at least mitigates most of these issues.)