### PR TITLE
www/caddy-custom: Update dependencies of extra modules

### DIFF
--- a/config/24.1/make.conf
+++ b/config/24.1/make.conf
@@ -93,8 +93,8 @@ www_webgrind_SET=		CALLGRAPH
 
 # for www/caddy-custom
 CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d06a83964da5573ee6a51f \
-				github.com/mholt/caddy-dynamicdns@7848511af7a4cfba383d911c3f9b2f73d2c3f3cb \
-				github.com/caddy-dns/cloudflare@2fa0c8ac916ab13ee14c836e59fec9d85857e429 \
+				github.com/mholt/caddy-dynamicdns@012a1d4347472eaf4b78826b86c8f35bda919f72 \
+				github.com/caddy-dns/cloudflare@44030f9306f4815aceed3b042c7f3d2c2b110c97 \
 				github.com/caddy-dns/route53@8e49e7546771bf6846e1531dcaff4925af5ddcde \
 				github.com/caddy-dns/duckdns@77870e12bac552ceb76917d82ced6db84b958c1f \
 				github.com/caddy-dns/digitalocean@9c71e343246b954976c9294a7062823605de9b9f \
@@ -103,11 +103,14 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/gandi@34327df7b24751de1b67e4b23b618c091aaeeff8 \
 				github.com/caddy-dns/azure@f2351591d9f258201499abc37d054b7e6366fefb \
 				github.com/caddy-dns/porkbun@4267f6797bf6543d7b20cdc8578a31764face4cf \
+				github.com/libdns/porkbun=github.com/Monviech/libdns-porkbun@e55534c0649a0497c60b8f6310bbd0b6091c9b8e \
 				github.com/caddy-dns/ovh@f71a5c6fd0073f94dd24e49233775d9b087dfe5d \
 				github.com/caddy-dns/namecheap@7095083a353829fc83632c34e8988fd8eb72f43d \
 				github.com/caddy-dns/netlify@575e1c71321efc4e9c34576e6942adb06b529a75 \
+				github.com/libdns/netlify=github.com/Monviech/libdns-netlify@b753c5b9f550aa804215e682a3932208369737c2 \
 				github.com/caddy-dns/acmedns@18621dd3e69e048eae80c4171ef56cb576dce2f4 \
 				github.com/caddy-dns/desec@e1e64971fe34c29ce3f4176464adb84d6890aa50 \
+				github.com/libdns/desec=github.com/Monviech/libdns-desec@6f34d8c03dbc5af29becedfc1b9cc76a74d3179d \
 				github.com/caddy-dns/powerdns@79c99dcd21421184998486265ad3242f79b8bda6 \
 				github.com/caddy-dns/ddnss@7f65108b0a6249d8e630fe2431143069c4317ee4 \
 				github.com/caddy-dns/njalla@57869f89026a2e8980d1b3fac5687e115e9acb36 \
@@ -116,4 +119,7 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/dinahosting@38b1acca4e37dac795cdd2ec239acb4fc3df7fef \
 				github.com/caddy-dns/ionos@751e8e24162290ee74bea465ae733a2bf49551a6 \
 				github.com/caddy-dns/hexonet@2df0595f17b1cae63394c9488eec55f4c1b63650 \
-				github.com/caddy-dns/mailinabox@46af20439f1f0b8e7fdd65c2069b77d3c2c96ef1
+				github.com/caddy-dns/mailinabox@46af20439f1f0b8e7fdd65c2069b77d3c2c96ef1 \
+				github.com/caddy-dns/netcup@1d6646da26bd930f9b5322c204fefe0e87b842cb \
+				github.com/libdns/netcup=github.com/Monviech/libdns-netcup@ad35b8a5a1a6d5894036b0ef0994b41f6700d3c8 \
+				github.com/caddy-dns/rfc2136@6096cd5db964c3f7757986b73ffa0617534497f7

--- a/config/24.1/make.conf
+++ b/config/24.1/make.conf
@@ -106,8 +106,7 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/libdns/porkbun=github.com/Monviech/libdns-porkbun@e55534c0649a0497c60b8f6310bbd0b6091c9b8e \
 				github.com/caddy-dns/ovh@f71a5c6fd0073f94dd24e49233775d9b087dfe5d \
 				github.com/caddy-dns/namecheap@7095083a353829fc83632c34e8988fd8eb72f43d \
-				github.com/caddy-dns/netlify@575e1c71321efc4e9c34576e6942adb06b529a75 \
-				github.com/libdns/netlify=github.com/Monviech/libdns-netlify@b753c5b9f550aa804215e682a3932208369737c2 \
+				github.com/caddy-dns/netlify@eaa9514e3b9fda329b317b937e2c6c0f23d11356 \
 				github.com/caddy-dns/acmedns@18621dd3e69e048eae80c4171ef56cb576dce2f4 \
 				github.com/caddy-dns/desec@e1e64971fe34c29ce3f4176464adb84d6890aa50 \
 				github.com/libdns/desec=github.com/Monviech/libdns-desec@6f34d8c03dbc5af29becedfc1b9cc76a74d3179d \


### PR DESCRIPTION
* Fix some build errors that are introduced due to a conflict between different libdns versions. caddy-dns mod.ts introduce dependencies to their libdns counterpart, e.g. caddy-dns/porkbun depends on libdns/porkbun.

* This dependency has been replaced using a "go mod replace" command that is passed via the xcaddy command. It replaces the libdns module with a custom patched one. The line can be completely removed in the future, since when the build error of the dependency has been fixed, it can be pulled from upstream again.

* The regession that is fixed is that cloudflare has newer dependencies than the rest of the dns modules. That forces indirect upgrades of libdns versions in modules and some smaller build errors in these modules are introduced (namely, uint and int errors at a few spots).

* Two new dns modules have been added, netcup (per request) and rfc2136 as a generalized provider for any kind of dynamic DNS update.