### PR TITLE
www/caddy-custom: Update desec dependency, remove custom patch

### DIFF
--- a/config/24.1/make.conf
+++ b/config/24.1/make.conf
@@ -108,8 +108,7 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/namecheap@7095083a353829fc83632c34e8988fd8eb72f43d \
 				github.com/caddy-dns/netlify@eaa9514e3b9fda329b317b937e2c6c0f23d11356 \
 				github.com/caddy-dns/acmedns@18621dd3e69e048eae80c4171ef56cb576dce2f4 \
-				github.com/caddy-dns/desec@e1e64971fe34c29ce3f4176464adb84d6890aa50 \
-				github.com/libdns/desec=github.com/Monviech/libdns-desec@6f34d8c03dbc5af29becedfc1b9cc76a74d3179d \
+				github.com/caddy-dns/desec@822a6a2014b221e8fa589fbcfd0395abe9ee90f6 \
 				github.com/caddy-dns/powerdns@79c99dcd21421184998486265ad3242f79b8bda6 \
 				github.com/caddy-dns/ddnss@7f65108b0a6249d8e630fe2431143069c4317ee4 \
 				github.com/caddy-dns/njalla@57869f89026a2e8980d1b3fac5687e115e9acb36 \


### PR DESCRIPTION
Upstream has been successfully patched:

https://github.com/libdns/desec/commit/a279f344b3a94dba7ef810dff5e3db31667957ad
https://github.com/caddy-dns/desec/commit/822a6a2014b221e8fa589fbcfd0395abe9ee90f6