### PR TITLE
www/caddy-custom: Remove rfc2136 since it causes build with caddy-2.8.1 to fail

### DIFF
--- a/config/24.1/make.conf
+++ b/config/24.1/make.conf
@@ -119,5 +119,4 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/hexonet@2df0595f17b1cae63394c9488eec55f4c1b63650 \
 				github.com/caddy-dns/mailinabox@46af20439f1f0b8e7fdd65c2069b77d3c2c96ef1 \
 				github.com/caddy-dns/netcup@1d6646da26bd930f9b5322c204fefe0e87b842cb \
-				github.com/libdns/netcup=github.com/Monviech/libdns-netcup@ad35b8a5a1a6d5894036b0ef0994b41f6700d3c8 \
-				github.com/caddy-dns/rfc2136@6096cd5db964c3f7757986b73ffa0617534497f7
+				github.com/libdns/netcup=github.com/Monviech/libdns-netcup@ad35b8a5a1a6d5894036b0ef0994b41f6700d3c8


### PR DESCRIPTION
The caddy-custom port just /pretends/ to build 2.7.6 (package is still called that way.) But it actually builds 2.8.1 now, very sneaky.

References:

https://github.com/opnsense/tools/pull/400#issuecomment-2140805870
https://forum.opnsense.org/index.php?topic=35828.msg200025#msg200025
https://forum.opnsense.org/index.php?topic=35828.msg200033#msg200033