### PR TITLE
www/caddy-custom: Update build for caddy-2.8.4, reintroduce rfc2136 with custom patch

### DIFF
--- a/config/24.1/make.conf
+++ b/config/24.1/make.conf
@@ -103,7 +103,7 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/gandi@34327df7b24751de1b67e4b23b618c091aaeeff8 \
 				github.com/caddy-dns/azure@f2351591d9f258201499abc37d054b7e6366fefb \
 				github.com/caddy-dns/porkbun@4267f6797bf6543d7b20cdc8578a31764face4cf \
-				github.com/libdns/porkbun=github.com/Monviech/libdns-porkbun@e55534c0649a0497c60b8f6310bbd0b6091c9b8e \
+				github.com/libdns/porkbun@6dda640b5aefc4692dadf90da3756818b6da2d92 \
 				github.com/caddy-dns/ovh@f71a5c6fd0073f94dd24e49233775d9b087dfe5d \
 				github.com/caddy-dns/namecheap@7095083a353829fc83632c34e8988fd8eb72f43d \
 				github.com/caddy-dns/netlify@eaa9514e3b9fda329b317b937e2c6c0f23d11356 \
@@ -119,4 +119,5 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/hexonet@2df0595f17b1cae63394c9488eec55f4c1b63650 \
 				github.com/caddy-dns/mailinabox@46af20439f1f0b8e7fdd65c2069b77d3c2c96ef1 \
 				github.com/caddy-dns/netcup@1d6646da26bd930f9b5322c204fefe0e87b842cb \
-				github.com/libdns/netcup=github.com/Monviech/libdns-netcup@ad35b8a5a1a6d5894036b0ef0994b41f6700d3c8
+				github.com/libdns/netcup=github.com/Monviech/libdns-netcup@366e5a9d96c92accf2523d94e9e7351da24a4643 \
+				github.com/caddy-dns/rfc2136=github.com/Monviech/caddy-dns-rfc2136@90072ec69f5de932676a726cc38cb8897ea404ac


### PR DESCRIPTION
- Update build for caddy-2.8.4, 
- Reintroduce rfc2136 with custom patch
- Update Porkbun and Netcup libdns dependency

**Attention, this build will fail with v2.7.6, it REQUIRES >=v2.8.0**