### PR TITLE
www/caddy-custom: Merge all upstream DNS Provider fixes into new build. Add 24.7 build.

### DIFF
--- a/config/24.1/make.conf
+++ b/config/24.1/make.conf
@@ -100,10 +100,9 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/digitalocean@9c71e343246b954976c9294a7062823605de9b9f \
 				github.com/caddy-dns/godaddy@7634a752ba5bda3977b461c60f5936eba3d02426 \
 				github.com/caddy-dns/googleclouddns@22c91a4de6d3c3a17d395e510e1b77eab82cdc3c \
-				github.com/caddy-dns/gandi@34327df7b24751de1b67e4b23b618c091aaeeff8 \
+				github.com/caddy-dns/gandi@d814cce86812e1e78544496e8f79e725058d8f1a \
 				github.com/caddy-dns/azure@f2351591d9f258201499abc37d054b7e6366fefb \
-				github.com/caddy-dns/porkbun@4267f6797bf6543d7b20cdc8578a31764face4cf \
-				github.com/libdns/porkbun@6dda640b5aefc4692dadf90da3756818b6da2d92 \
+				github.com/caddy-dns/porkbun@70de9b4c18f94dd2203927ab00ba104d62cb99a8 \
 				github.com/caddy-dns/ovh@f71a5c6fd0073f94dd24e49233775d9b087dfe5d \
 				github.com/caddy-dns/namecheap@7095083a353829fc83632c34e8988fd8eb72f43d \
 				github.com/caddy-dns/netlify@eaa9514e3b9fda329b317b937e2c6c0f23d11356 \
@@ -118,6 +117,5 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/ionos@751e8e24162290ee74bea465ae733a2bf49551a6 \
 				github.com/caddy-dns/hexonet@2df0595f17b1cae63394c9488eec55f4c1b63650 \
 				github.com/caddy-dns/mailinabox@46af20439f1f0b8e7fdd65c2069b77d3c2c96ef1 \
-				github.com/caddy-dns/netcup@1d6646da26bd930f9b5322c204fefe0e87b842cb \
-				github.com/libdns/netcup=github.com/Monviech/libdns-netcup@366e5a9d96c92accf2523d94e9e7351da24a4643 \
-				github.com/caddy-dns/rfc2136=github.com/Monviech/caddy-dns-rfc2136@90072ec69f5de932676a726cc38cb8897ea404ac
+				github.com/caddy-dns/netcup@a811da94403509715bd149669b07544706fd6d46 \
+				github.com/caddy-dns/rfc2136@b8df5e8730c9dcd6fce4b483530b96dcd46c0690

--- a/config/24.1/make.conf
+++ b/config/24.1/make.conf
@@ -130,4 +130,5 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/infomaniak@3755ae5b26f7bc73a94722ccd1abac8e3097bdd5 \
 				github.com/caddy-dns/directadmin@f9d0add7a54570edcd01e7a15f1e40f55ac0cb27 \
 				github.com/libdns/directadmin=github.com/Monviech/libdns-directadmin@0fd4de7d011f124cea92d7756fdaa6f6f2240e9d \
-				github.com/caddy-dns/hosttech@706ade8378b237a618bba8610a4c30da403a536e
+				github.com/caddy-dns/hosttech@706ade8378b237a618bba8610a4c30da403a536e \
+				github.com/caddy-dns/vultr@35618104157e8c72189928769d497cc37001a741

--- a/config/24.1/make.conf
+++ b/config/24.1/make.conf
@@ -98,7 +98,6 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/route53@8e49e7546771bf6846e1531dcaff4925af5ddcde \
 				github.com/caddy-dns/duckdns@77870e12bac552ceb76917d82ced6db84b958c1f \
 				github.com/caddy-dns/digitalocean@9c71e343246b954976c9294a7062823605de9b9f \
-				github.com/caddy-dns/godaddy@7634a752ba5bda3977b461c60f5936eba3d02426 \
 				github.com/caddy-dns/googleclouddns@22c91a4de6d3c3a17d395e510e1b77eab82cdc3c \
 				github.com/caddy-dns/gandi@d814cce86812e1e78544496e8f79e725058d8f1a \
 				github.com/caddy-dns/azure@f2351591d9f258201499abc37d054b7e6366fefb \
@@ -118,4 +117,17 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/hexonet@2df0595f17b1cae63394c9488eec55f4c1b63650 \
 				github.com/caddy-dns/mailinabox@46af20439f1f0b8e7fdd65c2069b77d3c2c96ef1 \
 				github.com/caddy-dns/netcup@a811da94403509715bd149669b07544706fd6d46 \
-				github.com/caddy-dns/rfc2136@b8df5e8730c9dcd6fce4b483530b96dcd46c0690
+				github.com/caddy-dns/rfc2136@b8df5e8730c9dcd6fce4b483530b96dcd46c0690 \
+				github.com/caddy-dns/dnsmadeeasy@91d629f293a577f1be3bb57529589ce39f4935b5 \
+				github.com/caddy-dns/bunny@71ced26b4224a713a918171a72c30c9908b59793 \
+				github.com/caddy-dns/civo@e2766c887ff53e6d24eb2646bbae85af77f41a78 \
+				github.com/caddy-dns/scaleway@561fd7f77b1b2022b4fd59d386179bfa65adebef \
+				github.com/caddy-dns/acmeproxy@69e9771dee25b5b7b8061f91e989e14573286e17 \
+				github.com/caddy-dns/inwx@706fe28db5b3f0017e735b46ef63d11c6db0112d \
+				github.com/caddy-dns/namedotcom@b9fae156cd97e1720f20aa03d82f96d2cf773e7a \
+				github.com/caddy-dns/easydns@1ac6695dce323169f238beacd73c1e7411d37df0 \
+				github.com/libdns/easydns=github.com/monviech/libdns-easydns@23d53bec7ce7b73a65c3bb745f96406d80eab00a \
+				github.com/caddy-dns/infomaniak@3755ae5b26f7bc73a94722ccd1abac8e3097bdd5 \
+				github.com/caddy-dns/directadmin@f9d0add7a54570edcd01e7a15f1e40f55ac0cb27 \
+				github.com/libdns/directadmin=github.com/Monviech/libdns-directadmin@0fd4de7d011f124cea92d7756fdaa6f6f2240e9d \
+				github.com/caddy-dns/hosttech@706ade8378b237a618bba8610a4c30da403a536e

--- a/config/24.1/make.conf
+++ b/config/24.1/make.conf
@@ -125,10 +125,8 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/acmeproxy@69e9771dee25b5b7b8061f91e989e14573286e17 \
 				github.com/caddy-dns/inwx@706fe28db5b3f0017e735b46ef63d11c6db0112d \
 				github.com/caddy-dns/namedotcom@b9fae156cd97e1720f20aa03d82f96d2cf773e7a \
-				github.com/caddy-dns/easydns@1ac6695dce323169f238beacd73c1e7411d37df0 \
-				github.com/libdns/easydns=github.com/monviech/libdns-easydns@23d53bec7ce7b73a65c3bb745f96406d80eab00a \
+				github.com/caddy-dns/easydns@1921d4f708b51d487e5c92793c7c5dae77421773 \
 				github.com/caddy-dns/infomaniak@3755ae5b26f7bc73a94722ccd1abac8e3097bdd5 \
-				github.com/caddy-dns/directadmin@f9d0add7a54570edcd01e7a15f1e40f55ac0cb27 \
-				github.com/libdns/directadmin=github.com/Monviech/libdns-directadmin@0fd4de7d011f124cea92d7756fdaa6f6f2240e9d \
+				github.com/caddy-dns/directadmin@48e27a0b9ce8e7bceda884e4e26e00461b674413 \
 				github.com/caddy-dns/hosttech@706ade8378b237a618bba8610a4c30da403a536e \
 				github.com/caddy-dns/vultr@35618104157e8c72189928769d497cc37001a741

--- a/config/24.7/make.conf
+++ b/config/24.7/make.conf
@@ -93,21 +93,21 @@ www_webgrind_SET=		CALLGRAPH
 
 # for www/caddy-custom
 CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d06a83964da5573ee6a51f \
-				github.com/mholt/caddy-dynamicdns@7848511af7a4cfba383d911c3f9b2f73d2c3f3cb \
-				github.com/caddy-dns/cloudflare@2fa0c8ac916ab13ee14c836e59fec9d85857e429 \
+				github.com/mholt/caddy-dynamicdns@012a1d4347472eaf4b78826b86c8f35bda919f72 \
+				github.com/caddy-dns/cloudflare@44030f9306f4815aceed3b042c7f3d2c2b110c97 \
 				github.com/caddy-dns/route53@8e49e7546771bf6846e1531dcaff4925af5ddcde \
 				github.com/caddy-dns/duckdns@77870e12bac552ceb76917d82ced6db84b958c1f \
 				github.com/caddy-dns/digitalocean@9c71e343246b954976c9294a7062823605de9b9f \
 				github.com/caddy-dns/godaddy@7634a752ba5bda3977b461c60f5936eba3d02426 \
 				github.com/caddy-dns/googleclouddns@22c91a4de6d3c3a17d395e510e1b77eab82cdc3c \
-				github.com/caddy-dns/gandi@34327df7b24751de1b67e4b23b618c091aaeeff8 \
+				github.com/caddy-dns/gandi@d814cce86812e1e78544496e8f79e725058d8f1a \
 				github.com/caddy-dns/azure@f2351591d9f258201499abc37d054b7e6366fefb \
-				github.com/caddy-dns/porkbun@4267f6797bf6543d7b20cdc8578a31764face4cf \
+				github.com/caddy-dns/porkbun@70de9b4c18f94dd2203927ab00ba104d62cb99a8 \
 				github.com/caddy-dns/ovh@f71a5c6fd0073f94dd24e49233775d9b087dfe5d \
 				github.com/caddy-dns/namecheap@7095083a353829fc83632c34e8988fd8eb72f43d \
-				github.com/caddy-dns/netlify@575e1c71321efc4e9c34576e6942adb06b529a75 \
+				github.com/caddy-dns/netlify@eaa9514e3b9fda329b317b937e2c6c0f23d11356 \
 				github.com/caddy-dns/acmedns@18621dd3e69e048eae80c4171ef56cb576dce2f4 \
-				github.com/caddy-dns/desec@e1e64971fe34c29ce3f4176464adb84d6890aa50 \
+				github.com/caddy-dns/desec@822a6a2014b221e8fa589fbcfd0395abe9ee90f6 \
 				github.com/caddy-dns/powerdns@79c99dcd21421184998486265ad3242f79b8bda6 \
 				github.com/caddy-dns/ddnss@7f65108b0a6249d8e630fe2431143069c4317ee4 \
 				github.com/caddy-dns/njalla@57869f89026a2e8980d1b3fac5687e115e9acb36 \
@@ -116,4 +116,6 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/dinahosting@38b1acca4e37dac795cdd2ec239acb4fc3df7fef \
 				github.com/caddy-dns/ionos@751e8e24162290ee74bea465ae733a2bf49551a6 \
 				github.com/caddy-dns/hexonet@2df0595f17b1cae63394c9488eec55f4c1b63650 \
-				github.com/caddy-dns/mailinabox@46af20439f1f0b8e7fdd65c2069b77d3c2c96ef1
+				github.com/caddy-dns/mailinabox@46af20439f1f0b8e7fdd65c2069b77d3c2c96ef1 \
+				github.com/caddy-dns/netcup@a811da94403509715bd149669b07544706fd6d46 \
+				github.com/caddy-dns/rfc2136@b8df5e8730c9dcd6fce4b483530b96dcd46c0690

--- a/config/24.7/make.conf
+++ b/config/24.7/make.conf
@@ -130,4 +130,5 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/infomaniak@3755ae5b26f7bc73a94722ccd1abac8e3097bdd5 \
 				github.com/caddy-dns/directadmin@f9d0add7a54570edcd01e7a15f1e40f55ac0cb27 \
 				github.com/libdns/directadmin=github.com/Monviech/libdns-directadmin@0fd4de7d011f124cea92d7756fdaa6f6f2240e9d \
-				github.com/caddy-dns/hosttech@706ade8378b237a618bba8610a4c30da403a536e
+				github.com/caddy-dns/hosttech@706ade8378b237a618bba8610a4c30da403a536e \
+				github.com/caddy-dns/vultr@35618104157e8c72189928769d497cc37001a741

--- a/config/24.7/make.conf
+++ b/config/24.7/make.conf
@@ -98,7 +98,6 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/route53@8e49e7546771bf6846e1531dcaff4925af5ddcde \
 				github.com/caddy-dns/duckdns@77870e12bac552ceb76917d82ced6db84b958c1f \
 				github.com/caddy-dns/digitalocean@9c71e343246b954976c9294a7062823605de9b9f \
-				github.com/caddy-dns/godaddy@7634a752ba5bda3977b461c60f5936eba3d02426 \
 				github.com/caddy-dns/googleclouddns@22c91a4de6d3c3a17d395e510e1b77eab82cdc3c \
 				github.com/caddy-dns/gandi@d814cce86812e1e78544496e8f79e725058d8f1a \
 				github.com/caddy-dns/azure@f2351591d9f258201499abc37d054b7e6366fefb \
@@ -118,4 +117,17 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/hexonet@2df0595f17b1cae63394c9488eec55f4c1b63650 \
 				github.com/caddy-dns/mailinabox@46af20439f1f0b8e7fdd65c2069b77d3c2c96ef1 \
 				github.com/caddy-dns/netcup@a811da94403509715bd149669b07544706fd6d46 \
-				github.com/caddy-dns/rfc2136@b8df5e8730c9dcd6fce4b483530b96dcd46c0690
+				github.com/caddy-dns/rfc2136@b8df5e8730c9dcd6fce4b483530b96dcd46c0690 \
+				github.com/caddy-dns/dnsmadeeasy@91d629f293a577f1be3bb57529589ce39f4935b5 \
+				github.com/caddy-dns/bunny@71ced26b4224a713a918171a72c30c9908b59793 \
+				github.com/caddy-dns/civo@e2766c887ff53e6d24eb2646bbae85af77f41a78 \
+				github.com/caddy-dns/scaleway@561fd7f77b1b2022b4fd59d386179bfa65adebef \
+				github.com/caddy-dns/acmeproxy@69e9771dee25b5b7b8061f91e989e14573286e17 \
+				github.com/caddy-dns/inwx@706fe28db5b3f0017e735b46ef63d11c6db0112d \
+				github.com/caddy-dns/namedotcom@b9fae156cd97e1720f20aa03d82f96d2cf773e7a \
+				github.com/caddy-dns/easydns@1ac6695dce323169f238beacd73c1e7411d37df0 \
+				github.com/libdns/easydns=github.com/monviech/libdns-easydns@23d53bec7ce7b73a65c3bb745f96406d80eab00a \
+				github.com/caddy-dns/infomaniak@3755ae5b26f7bc73a94722ccd1abac8e3097bdd5 \
+				github.com/caddy-dns/directadmin@f9d0add7a54570edcd01e7a15f1e40f55ac0cb27 \
+				github.com/libdns/directadmin=github.com/Monviech/libdns-directadmin@0fd4de7d011f124cea92d7756fdaa6f6f2240e9d \
+				github.com/caddy-dns/hosttech@706ade8378b237a618bba8610a4c30da403a536e

--- a/config/24.7/make.conf
+++ b/config/24.7/make.conf
@@ -125,10 +125,8 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/acmeproxy@69e9771dee25b5b7b8061f91e989e14573286e17 \
 				github.com/caddy-dns/inwx@706fe28db5b3f0017e735b46ef63d11c6db0112d \
 				github.com/caddy-dns/namedotcom@b9fae156cd97e1720f20aa03d82f96d2cf773e7a \
-				github.com/caddy-dns/easydns@1ac6695dce323169f238beacd73c1e7411d37df0 \
-				github.com/libdns/easydns=github.com/monviech/libdns-easydns@23d53bec7ce7b73a65c3bb745f96406d80eab00a \
+				github.com/caddy-dns/easydns@1921d4f708b51d487e5c92793c7c5dae77421773 \
 				github.com/caddy-dns/infomaniak@3755ae5b26f7bc73a94722ccd1abac8e3097bdd5 \
-				github.com/caddy-dns/directadmin@f9d0add7a54570edcd01e7a15f1e40f55ac0cb27 \
-				github.com/libdns/directadmin=github.com/Monviech/libdns-directadmin@0fd4de7d011f124cea92d7756fdaa6f6f2240e9d \
+				github.com/caddy-dns/directadmin@48e27a0b9ce8e7bceda884e4e26e00461b674413 \
 				github.com/caddy-dns/hosttech@706ade8378b237a618bba8610a4c30da403a536e \
 				github.com/caddy-dns/vultr@35618104157e8c72189928769d497cc37001a741


### PR DESCRIPTION
- Most of my upstream PRs got merged and new versions have been made. Removed all custom patches in favor of the upstream versions.
- copied this new stable config into 24.7 too