### PR TITLE
www/caddy-custom: Update Route53 and Cloudflare dependencies.

### DIFF
--- a/config/24.1/make.conf
+++ b/config/24.1/make.conf
@@ -94,8 +94,8 @@ www_webgrind_SET=		CALLGRAPH
 # for www/caddy-custom
 CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d06a83964da5573ee6a51f \
 				github.com/mholt/caddy-dynamicdns@012a1d4347472eaf4b78826b86c8f35bda919f72 \
-				github.com/caddy-dns/cloudflare@44030f9306f4815aceed3b042c7f3d2c2b110c97 \
-				github.com/caddy-dns/route53@8e49e7546771bf6846e1531dcaff4925af5ddcde \
+				github.com/caddy-dns/cloudflare@89f16b99c18ef49c8bb470a82f895bce01cbaece \
+				github.com/caddy-dns/route53@cdab4f43673f4ab12b5dda1c6aef8d9de44f0c86 \
 				github.com/caddy-dns/duckdns@77870e12bac552ceb76917d82ced6db84b958c1f \
 				github.com/caddy-dns/digitalocean@9c71e343246b954976c9294a7062823605de9b9f \
 				github.com/caddy-dns/googleclouddns@22c91a4de6d3c3a17d395e510e1b77eab82cdc3c \

--- a/config/24.7/make.conf
+++ b/config/24.7/make.conf
@@ -94,8 +94,8 @@ www_webgrind_SET=		CALLGRAPH
 # for www/caddy-custom
 CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d06a83964da5573ee6a51f \
 				github.com/mholt/caddy-dynamicdns@012a1d4347472eaf4b78826b86c8f35bda919f72 \
-				github.com/caddy-dns/cloudflare@44030f9306f4815aceed3b042c7f3d2c2b110c97 \
-				github.com/caddy-dns/route53@8e49e7546771bf6846e1531dcaff4925af5ddcde \
+				github.com/caddy-dns/cloudflare@89f16b99c18ef49c8bb470a82f895bce01cbaece \
+				github.com/caddy-dns/route53@cdab4f43673f4ab12b5dda1c6aef8d9de44f0c86 \
 				github.com/caddy-dns/duckdns@77870e12bac552ceb76917d82ced6db84b958c1f \
 				github.com/caddy-dns/digitalocean@9c71e343246b954976c9294a7062823605de9b9f \
 				github.com/caddy-dns/googleclouddns@22c91a4de6d3c3a17d395e510e1b77eab82cdc3c \


### PR DESCRIPTION
References:
- https://www.reddit.com/r/opnsense/comments/1dwbr88/issue_using_oscaddy_to_generate_wildcard_cert/
- https://github.com/opnsense/plugins/pull/4073