### PR TITLE
Add tools for updating intel network cards firmware

### DIFF
--- a/config/24.7/ports.conf
+++ b/config/24.7/ports.conf
@@ -212,6 +212,10 @@ sysutils/flashrom				arm,aarch64
 sysutils/flock
 sysutils/freeipmi				arm,aarch64
 sysutils/hw-probe				arm
+sysutils/intel-qcu
+sysutils/intel-nvmupdate-10g
+sysutils/intel-nvmupdate-40g
+sysutils/intel-nvmupdate-100g
 sysutils/iohyve					arm
 sysutils/lcdproc				arm,aarch64
 sysutils/monit


### PR DESCRIPTION
The documentation for the intel ixl driver states additional tools to update the firmware:

   •   To change the behavior of the QSFP+ ports on	 XL710	adapters,  use
   the	Intel  QCU  (QSFP+  configuration  utility);  installed	by the
   sysutils/intel-qcu package.

   •   To update the firmware on an	adapter, use  the  Intel  Non-Volatile
   Memory     (NVM)	Update	   Utility;	installed    by	   the
   sysutils/intel-nvmupdate-10g,   sysutils/intel-nvmupdate-40g,    or
   sysutils/intel-nvmupdate-100g, package.

See https://man.freebsd.org/cgi/man.cgi?query=ixl&sektion=4&format=html

#412 