### PR TITLE
aarch64/ARM64 DVD creation

### DIFF
--- a/build/dvd.sh
+++ b/build/dvd.sh
@@ -55,7 +55,8 @@ if [ -n "${PRODUCT_UEFI}" -a -z "${PRODUCT_UEFI%%*"${SELF}"*}" ]; then
 
 	setup_efiboot ${STAGEDIR}/efiboot.img \
 	    ${STAGEDIR}/work/boot/loader.efi 2048 12
-elif [ ${PRODUCT_ARCH} = "amd64" ]; then
+fi
+if [ ${PRODUCT_ARCH} = "amd64" ]; then
 	LEGACYBOOT="-o 'bootimage=i386;${STAGEDIR}/work/boot/cdboot' -o no-emul-boot"
 fi
 

--- a/build/dvd.sh
+++ b/build/dvd.sh
@@ -50,7 +50,11 @@ UEFIBOOT=
 LEGACYBOOT=
 
 if [ -n "${PRODUCT_UEFI}" -a -z "${PRODUCT_UEFI%%*"${SELF}"*}" ]; then
-	UEFIBOOT="-o bootimage=efi;${STAGEDIR}/efiboot.img"
+        if [ ${PRODUCT_ARCH} = "amd64" ]; then
+                UEFIBOOT="-o bootimage=i386;${STAGEDIR}/efiboot.img"
+        else
+                UEFIBOOT="-o bootimage=efi;${STAGEDIR}/efiboot.img"
+        fi
 	UEFIBOOT="${UEFIBOOT} -o no-emul-boot -o platformid=efi"
 
 	setup_efiboot ${STAGEDIR}/efiboot.img \

--- a/build/dvd.sh
+++ b/build/dvd.sh
@@ -47,13 +47,16 @@ setup_mtree ${STAGEDIR}/work
 setup_entropy ${STAGEDIR}/work
 
 UEFIBOOT=
+LEGACYBOOT=
 
 if [ -n "${PRODUCT_UEFI}" -a -z "${PRODUCT_UEFI%%*"${SELF}"*}" ]; then
-	UEFIBOOT="-o bootimage=i386;${STAGEDIR}/efiboot.img"
+	UEFIBOOT="-o bootimage=efi;${STAGEDIR}/efiboot.img"
 	UEFIBOOT="${UEFIBOOT} -o no-emul-boot -o platformid=efi"
 
 	setup_efiboot ${STAGEDIR}/efiboot.img \
 	    ${STAGEDIR}/work/boot/loader.efi 2048 12
+elif [ ${PRODUCT_ARCH} = "amd64" ]; then
+	LEGACYBOOT="-o 'bootimage=i386;${STAGEDIR}/work/boot/cdboot' -o no-emul-boot"
 fi
 
 cat > ${STAGEDIR}/work/etc/fstab << EOF
@@ -65,7 +68,7 @@ EOF
 echo -n ">>> Building dvd image... "
 
 makefs -t cd9660 \
-    -o 'bootimage=i386;'"${STAGEDIR}"'/work/boot/cdboot' -o no-emul-boot \
+    ${LEGACYBOOT} \
     ${UEFIBOOT} -o label=${DVDLABEL} -o rockridge ${DVDIMG} ${STAGEDIR}/work
 
 echo "done"

--- a/build/dvd.sh
+++ b/build/dvd.sh
@@ -57,7 +57,7 @@ if [ -n "${PRODUCT_UEFI}" -a -z "${PRODUCT_UEFI%%*"${SELF}"*}" ]; then
 	    ${STAGEDIR}/work/boot/loader.efi 2048 12
 fi
 if [ ${PRODUCT_ARCH} = "amd64" ]; then
-	LEGACYBOOT="-o 'bootimage=i386;${STAGEDIR}/work/boot/cdboot' -o no-emul-boot"
+	LEGACYBOOT="-o bootimage=i386;${STAGEDIR}/work/boot/cdboot -o no-emul-boot"
 fi
 
 cat > ${STAGEDIR}/work/etc/fstab << EOF


### PR DESCRIPTION
Removes requirement for i386 cdboot for non-amd64 architectures. Allows aarch64 dvd target to build.

As many arm platforms support UEFI, having a bootable dvd image is convenient.

Before:

```sh
Populating `/usr/obj/usr/tools/config/24.1/aarch64/efiboot.img'
Image `/usr/obj/usr/tools/config/24.1/aarch64/efiboot.img' complete
>>> Building dvd image... makefs: cd9660_add_boot_disk: lstat("/usr/obj/usr/tools/config/24.1/aarch64/work/boot/cdboot"): No such file or directory
*** Error code 1

Stop.
make: stopped in /usr/tools/
```

After:
```sh
Populating `/usr/obj/usr/tools/config/24.1/aarch64/efiboot.img'
Image `/usr/obj/usr/tools/config/24.1/aarch64/efiboot.img' complete
>>> Building dvd image... done
```