### PR TITLE
www/caddy-custom: Add ratelimit module for CLI usage

### DIFF
--- a/config/24.7/make.conf
+++ b/config/24.7/make.conf
@@ -97,6 +97,7 @@ www_webgrind_SET=		CALLGRAPH
 CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d06a83964da5573ee6a51f \
 				github.com/mholt/caddy-dynamicdns@d8dab1bbf3fc592032f71dacc14510475b4e3e9a \
 				github.com/mholt/caddy-l4@e23bce071de6534a33e7a0c0838b111e11c59f54 \
+				github.com/mholt/caddy-ratelimit@12435ecef5dbb1b137eb68002b85d775a9d5cdb2 \
 				github.com/caddy-dns/cloudflare@89f16b99c18ef49c8bb470a82f895bce01cbaece \
 				github.com/caddy-dns/route53@5e0037b52d9b6dbe8ef47d5d3fdf42d7f87ebf79 \
 				github.com/caddy-dns/duckdns@77870e12bac552ceb76917d82ced6db84b958c1f \


### PR DESCRIPTION
Build in xcaddy checks out, doesn't hurt adding this for the CLI crowd who only use this port without GUI in OPNsense.

Fixes: https://github.com/opnsense/plugins/issues/4236