### PR TITLE
www/caddy-custom: Update dependencies

### DIFF
--- a/config/24.7/make.conf
+++ b/config/24.7/make.conf
@@ -96,22 +96,22 @@ www_webgrind_SET=		CALLGRAPH
 # for www/caddy-custom
 CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d06a83964da5573ee6a51f \
 				github.com/mholt/caddy-dynamicdns@d8dab1bbf3fc592032f71dacc14510475b4e3e9a \
-				github.com/mholt/caddy-l4@e23bce071de6534a33e7a0c0838b111e11c59f54 \
+				github.com/mholt/caddy-l4@4f012d4517cf65b3a2da1308ec6e770c0cf0b656 \
 				github.com/mholt/caddy-ratelimit@12435ecef5dbb1b137eb68002b85d775a9d5cdb2 \
 				github.com/caddy-dns/cloudflare@89f16b99c18ef49c8bb470a82f895bce01cbaece \
-				github.com/caddy-dns/route53@5e0037b52d9b6dbe8ef47d5d3fdf42d7f87ebf79 \
+				github.com/caddy-dns/route53@d92230e22b716e9b0c8bc1086477415f8b90e77f \
 				github.com/caddy-dns/duckdns@77870e12bac552ceb76917d82ced6db84b958c1f \
 				github.com/caddy-dns/digitalocean@9c71e343246b954976c9294a7062823605de9b9f \
 				github.com/caddy-dns/googleclouddns@22c91a4de6d3c3a17d395e510e1b77eab82cdc3c \
 				github.com/caddy-dns/gandi@d814cce86812e1e78544496e8f79e725058d8f1a \
 				github.com/caddy-dns/azure@f2351591d9f258201499abc37d054b7e6366fefb \
 				github.com/caddy-dns/porkbun@70de9b4c18f94dd2203927ab00ba104d62cb99a8 \
-				github.com/caddy-dns/ovh@f71a5c6fd0073f94dd24e49233775d9b087dfe5d \
+				github.com/caddy-dns/ovh@62cc061d0f87156769feb16b6a81e97462ef6cee \
 				github.com/caddy-dns/namecheap@7095083a353829fc83632c34e8988fd8eb72f43d \
 				github.com/caddy-dns/netlify@eaa9514e3b9fda329b317b937e2c6c0f23d11356 \
 				github.com/caddy-dns/acmedns@18621dd3e69e048eae80c4171ef56cb576dce2f4 \
 				github.com/caddy-dns/desec@822a6a2014b221e8fa589fbcfd0395abe9ee90f6 \
-				github.com/caddy-dns/powerdns@79c99dcd21421184998486265ad3242f79b8bda6 \
+				github.com/caddy-dns/powerdns@fbd76808d64f57c80d4d62587dd14b14f06aefc7 \
 				github.com/caddy-dns/ddnss@7f65108b0a6249d8e630fe2431143069c4317ee4 \
 				github.com/caddy-dns/njalla@57869f89026a2e8980d1b3fac5687e115e9acb36 \
 				github.com/caddy-dns/linode@6fa218b5e8d6495dd96359b5550937f10234b360 \
@@ -119,7 +119,7 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/dinahosting@38b1acca4e37dac795cdd2ec239acb4fc3df7fef \
 				github.com/caddy-dns/ionos@041b720e83ffd1245086edf4b0259a802fc586ba \
 				github.com/caddy-dns/hexonet@2df0595f17b1cae63394c9488eec55f4c1b63650 \
-				github.com/caddy-dns/mailinabox@46af20439f1f0b8e7fdd65c2069b77d3c2c96ef1 \
+				github.com/caddy-dns/mailinabox@39d0e3ce8e259f6d1b98b6c417fc79a0a1708e91 \
 				github.com/caddy-dns/netcup@a811da94403509715bd149669b07544706fd6d46 \
 				github.com/caddy-dns/rfc2136@b8df5e8730c9dcd6fce4b483530b96dcd46c0690 \
 				github.com/caddy-dns/dnsmadeeasy@91d629f293a577f1be3bb57529589ce39f4935b5 \


### PR DESCRIPTION
An important change is the update of caddy-l4 which might fix something. (yeah pretty vague but I got the hint to go to latest here.)

Might be this that has to be fixed for some users: https://github.com/mholt/caddy-l4/commit/22a03931ae46d0decc068e8d1ffe83e6187ed812

PR: https://forum.opnsense.org/index.php?topic=42955.0

At the same time I checked and some DNS Providers also had updates so put them in here too.