### PR TITLE
www/caddy-custom: Update layer4 module

### DIFF
--- a/config/24.7/make.conf
+++ b/config/24.7/make.conf
@@ -98,7 +98,7 @@ www_webgrind_SET=		CALLGRAPH
 # for www/caddy-custom
 CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d06a83964da5573ee6a51f \
 				github.com/mholt/caddy-dynamicdns@d8dab1bbf3fc592032f71dacc14510475b4e3e9a \
-				github.com/mholt/caddy-l4@4f012d4517cf65b3a2da1308ec6e770c0cf0b656 \
+				github.com/mholt/caddy-l4@bdee6a6620c02aca4817e6c3091fed26aa10940c \
 				github.com/mholt/caddy-ratelimit@12435ecef5dbb1b137eb68002b85d775a9d5cdb2 \
 				github.com/caddy-dns/cloudflare@89f16b99c18ef49c8bb470a82f895bce01cbaece \
 				github.com/caddy-dns/route53@d92230e22b716e9b0c8bc1086477415f8b90e77f \


### PR DESCRIPTION
Adds these two commits:

https://github.com/mholt/caddy-l4/commit/ea27408a3384a7f33b5d1cb49ec592cf76942be6
https://github.com/mholt/caddy-l4/commit/bdee6a6620c02aca4817e6c3091fed26aa10940c

Fixes (for now) that the TLS matcher in the Layer 4 module didn't work anymore due to some latest Chrome and Edge updates.

For tracking that issue:
https://github.com/mholt/caddy-l4/issues/250

PR: https://forum.opnsense.org/index.php?topic=42955.0