### PR TITLE
www/caddy-custom: Update dependencies

### DIFF
--- a/config/24.7/make.conf
+++ b/config/24.7/make.conf
@@ -97,8 +97,8 @@ www_webgrind_SET=		CALLGRAPH
 
 # for www/caddy-custom
 CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d06a83964da5573ee6a51f \
-				github.com/mholt/caddy-dynamicdns@d8dab1bbf3fc592032f71dacc14510475b4e3e9a \
-				github.com/mholt/caddy-l4@bdee6a6620c02aca4817e6c3091fed26aa10940c \
+				github.com/mholt/caddy-dynamicdns@7c818ab3fc3485a72a346f85c77810725f19f9cf \
+				github.com/mholt/caddy-l4@16b3b200e1828ec0ad7cfdf88bf67b3a0c80cda0 \
 				github.com/mholt/caddy-ratelimit@12435ecef5dbb1b137eb68002b85d775a9d5cdb2 \
 				github.com/caddy-dns/cloudflare@89f16b99c18ef49c8bb470a82f895bce01cbaece \
 				github.com/caddy-dns/route53@d92230e22b716e9b0c8bc1086477415f8b90e77f \
@@ -107,7 +107,7 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/googleclouddns@22c91a4de6d3c3a17d395e510e1b77eab82cdc3c \
 				github.com/caddy-dns/gandi@d814cce86812e1e78544496e8f79e725058d8f1a \
 				github.com/caddy-dns/azure@f2351591d9f258201499abc37d054b7e6366fefb \
-				github.com/caddy-dns/porkbun@70de9b4c18f94dd2203927ab00ba104d62cb99a8 \
+				github.com/caddy-dns/porkbun@6b466fe4a00ba161d78669f048602ac70e706076 \
 				github.com/caddy-dns/ovh@62cc061d0f87156769feb16b6a81e97462ef6cee \
 				github.com/caddy-dns/namecheap@7095083a353829fc83632c34e8988fd8eb72f43d \
 				github.com/caddy-dns/netlify@eaa9514e3b9fda329b317b937e2c6c0f23d11356 \
@@ -124,7 +124,7 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/mailinabox@39d0e3ce8e259f6d1b98b6c417fc79a0a1708e91 \
 				github.com/caddy-dns/netcup@a811da94403509715bd149669b07544706fd6d46 \
 				github.com/caddy-dns/rfc2136@b8df5e8730c9dcd6fce4b483530b96dcd46c0690 \
-				github.com/caddy-dns/dnsmadeeasy@91d629f293a577f1be3bb57529589ce39f4935b5 \
+				github.com/caddy-dns/dnsmadeeasy@429f104d55d714143ebdcbf3e3effdc9039572e0 \
 				github.com/caddy-dns/bunny@71ced26b4224a713a918171a72c30c9908b59793 \
 				github.com/caddy-dns/civo@e2766c887ff53e6d24eb2646bbae85af77f41a78 \
 				github.com/caddy-dns/scaleway@561fd7f77b1b2022b4fd59d386179bfa65adebef \

--- a/config/24.7/make.conf
+++ b/config/24.7/make.conf
@@ -98,7 +98,7 @@ www_webgrind_SET=		CALLGRAPH
 # for www/caddy-custom
 CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d06a83964da5573ee6a51f \
 				github.com/mholt/caddy-dynamicdns@7c818ab3fc3485a72a346f85c77810725f19f9cf \
-				github.com/mholt/caddy-l4@16b3b200e1828ec0ad7cfdf88bf67b3a0c80cda0 \
+				github.com/mholt/caddy-l4@ec8fae2093229e1ac29d7ef7b5dd5b209c0b08b8 \
 				github.com/mholt/caddy-ratelimit@12435ecef5dbb1b137eb68002b85d775a9d5cdb2 \
 				github.com/caddy-dns/cloudflare@89f16b99c18ef49c8bb470a82f895bce01cbaece \
 				github.com/caddy-dns/route53@d92230e22b716e9b0c8bc1086477415f8b90e77f \


### PR DESCRIPTION
- Update Layer 4 module back to main branch to include bugfixes, add winbox and openvpn matcher
- Porkbun (API endpoint change)
- Patch that caddy-l4 does not stop under some circumstances on sigterm