### PR TITLE
config/plugins: ignore Zenarmor vendor repository on aarch64

### DIFF
--- a/config/24.7/plugins.conf
+++ b/config/24.7/plugins.conf
@@ -84,7 +84,7 @@ sysutils/smart					arm
 sysutils/virtualbox				arm,aarch64
 sysutils/vmware					arm
 sysutils/xen					arm,aarch64
-vendor/sunnyvalley				arm
+vendor/sunnyvalley				arm,aarch64
 www/OPNProxy					arm
 www/c-icap					arm
 www/cache


### PR DESCRIPTION
Zenarmor is not available for OPNsense aarch64.
Bug report: https://forum.opnsense.org/index.php?topic=35828.msg218005#msg218005