### PR TITLE
prefetch: add support for tests set

### DIFF
--- a/build/prefetch.sh
+++ b/build/prefetch.sh
@@ -48,7 +48,7 @@ for ARG in ${@}; do
 			fetch -o ${SETSDIR} ${URL}.${SUFFIX} || true
 		done
 		;;
-	base|kernel)
+	base|kernel|tests)
 		sh ./clean.sh ${ARG}
 		URL="${MIRRORSETDIR}/${ARG}-${VERSION}-${PRODUCT_ARCH}"
 		for SUFFIX in txz.sig txz; do


### PR DESCRIPTION
Building images now requires the `tests` set. Allow `make prefetch-tests` to speed up building images.