### PR TITLE
add OATH Toolkit for 2FA support in Acme Client

### DIFF
--- a/config/24.7/ports.conf
+++ b/config/24.7/ports.conf
@@ -184,6 +184,7 @@ security/expiretable
 security/gnupg					arm
 security/maltrail				arm
 security/nmap					arm
+security/oath-toolkit
 security/openconnect				arm
 security/openssh-portable
 security/openvpn

--- a/config/25.1/ports.conf
+++ b/config/25.1/ports.conf
@@ -184,6 +184,7 @@ security/expiretable
 security/gnupg					arm
 security/maltrail				arm
 security/nmap					arm
+security/oath-toolkit
 security/openconnect				arm
 security/openssh-portable
 security/openvpn


### PR DESCRIPTION
The Acme Client plugin (well, in fact the underlying acme.sh) supports a wide range of DNS providers to generate certificates. When one of these DNS providers has 2FA enabled, additional tools are required to generate the authentication token. Otherwise the creation of the certificate will fail.

This PR adds OATH Toolkit to support 2FA for INWX:
https://github.com/opnsense/plugins/issues/3942

Other DNS APIs may use the OATH Toolkit too, so this is not the only use-case.