### PR TITLE
www/caddy-custom: Revise build for caddy-v2.9.0

### DIFF
--- a/config/24.7/make.conf
+++ b/config/24.7/make.conf
@@ -98,27 +98,19 @@ www_webgrind_SET=		CALLGRAPH
 # for www/caddy-custom
 CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d06a83964da5573ee6a51f \
 				github.com/mholt/caddy-dynamicdns@7c818ab3fc3485a72a346f85c77810725f19f9cf \
-				github.com/mholt/caddy-l4@ec8fae2093229e1ac29d7ef7b5dd5b209c0b08b8 \
+				github.com/mholt/caddy-l4@6e5f5e311ead9de02c96c44e071947ab273b1f59 \
 				github.com/mholt/caddy-ratelimit@12435ecef5dbb1b137eb68002b85d775a9d5cdb2 \
 				github.com/caddy-dns/cloudflare@89f16b99c18ef49c8bb470a82f895bce01cbaece \
-				github.com/caddy-dns/route53@d92230e22b716e9b0c8bc1086477415f8b90e77f \
 				github.com/caddy-dns/duckdns@77870e12bac552ceb76917d82ced6db84b958c1f \
-				github.com/caddy-dns/digitalocean@9c71e343246b954976c9294a7062823605de9b9f \
-				github.com/caddy-dns/googleclouddns@22c91a4de6d3c3a17d395e510e1b77eab82cdc3c \
 				github.com/caddy-dns/gandi@d814cce86812e1e78544496e8f79e725058d8f1a \
 				github.com/caddy-dns/azure@f2351591d9f258201499abc37d054b7e6366fefb \
 				github.com/caddy-dns/porkbun@6b466fe4a00ba161d78669f048602ac70e706076 \
 				github.com/caddy-dns/ovh@62cc061d0f87156769feb16b6a81e97462ef6cee \
 				github.com/caddy-dns/namecheap@7095083a353829fc83632c34e8988fd8eb72f43d \
-				github.com/caddy-dns/netlify@eaa9514e3b9fda329b317b937e2c6c0f23d11356 \
 				github.com/caddy-dns/acmedns@18621dd3e69e048eae80c4171ef56cb576dce2f4 \
 				github.com/caddy-dns/desec@822a6a2014b221e8fa589fbcfd0395abe9ee90f6 \
 				github.com/caddy-dns/powerdns@fbd76808d64f57c80d4d62587dd14b14f06aefc7 \
-				github.com/caddy-dns/ddnss@7f65108b0a6249d8e630fe2431143069c4317ee4 \
-				github.com/caddy-dns/njalla@57869f89026a2e8980d1b3fac5687e115e9acb36 \
 				github.com/caddy-dns/linode@6fa218b5e8d6495dd96359b5550937f10234b360 \
-				github.com/caddy-dns/tencentcloud@d0f5c8c8114232a2c04f6912fb5de54d02e58245 \
-				github.com/caddy-dns/dinahosting@38b1acca4e37dac795cdd2ec239acb4fc3df7fef \
 				github.com/caddy-dns/ionos@041b720e83ffd1245086edf4b0259a802fc586ba \
 				github.com/caddy-dns/hexonet@2df0595f17b1cae63394c9488eec55f4c1b63650 \
 				github.com/caddy-dns/mailinabox@39d0e3ce8e259f6d1b98b6c417fc79a0a1708e91 \
@@ -126,14 +118,11 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/rfc2136@b8df5e8730c9dcd6fce4b483530b96dcd46c0690 \
 				github.com/caddy-dns/dnsmadeeasy@429f104d55d714143ebdcbf3e3effdc9039572e0 \
 				github.com/caddy-dns/bunny@71ced26b4224a713a918171a72c30c9908b59793 \
-				github.com/caddy-dns/civo@e2766c887ff53e6d24eb2646bbae85af77f41a78 \
 				github.com/caddy-dns/scaleway@561fd7f77b1b2022b4fd59d386179bfa65adebef \
 				github.com/caddy-dns/acmeproxy@69e9771dee25b5b7b8061f91e989e14573286e17 \
 				github.com/caddy-dns/inwx@706fe28db5b3f0017e735b46ef63d11c6db0112d \
 				github.com/caddy-dns/namedotcom@b9fae156cd97e1720f20aa03d82f96d2cf773e7a \
-				github.com/caddy-dns/easydns@9f2603a3f99463d342027831014f0a3330111f4c \
 				github.com/caddy-dns/infomaniak@3755ae5b26f7bc73a94722ccd1abac8e3097bdd5 \
 				github.com/caddy-dns/directadmin@48e27a0b9ce8e7bceda884e4e26e00461b674413 \
-				github.com/caddy-dns/hosttech@706ade8378b237a618bba8610a4c30da403a536e \
 				github.com/caddy-dns/vultr@35618104157e8c72189928769d497cc37001a741 \
 				github.com/caddy-dns/hetzner@23343c04385f08c188b3f43f7c21e5f6a65dedcb

--- a/config/25.1/make.conf
+++ b/config/25.1/make.conf
@@ -98,27 +98,19 @@ www_webgrind_SET=		CALLGRAPH
 # for www/caddy-custom
 CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d06a83964da5573ee6a51f \
 				github.com/mholt/caddy-dynamicdns@7c818ab3fc3485a72a346f85c77810725f19f9cf \
-				github.com/mholt/caddy-l4@ec8fae2093229e1ac29d7ef7b5dd5b209c0b08b8 \
+				github.com/mholt/caddy-l4@6e5f5e311ead9de02c96c44e071947ab273b1f59 \
 				github.com/mholt/caddy-ratelimit@12435ecef5dbb1b137eb68002b85d775a9d5cdb2 \
 				github.com/caddy-dns/cloudflare@89f16b99c18ef49c8bb470a82f895bce01cbaece \
-				github.com/caddy-dns/route53@d92230e22b716e9b0c8bc1086477415f8b90e77f \
 				github.com/caddy-dns/duckdns@77870e12bac552ceb76917d82ced6db84b958c1f \
-				github.com/caddy-dns/digitalocean@9c71e343246b954976c9294a7062823605de9b9f \
-				github.com/caddy-dns/googleclouddns@22c91a4de6d3c3a17d395e510e1b77eab82cdc3c \
 				github.com/caddy-dns/gandi@d814cce86812e1e78544496e8f79e725058d8f1a \
 				github.com/caddy-dns/azure@f2351591d9f258201499abc37d054b7e6366fefb \
 				github.com/caddy-dns/porkbun@6b466fe4a00ba161d78669f048602ac70e706076 \
 				github.com/caddy-dns/ovh@62cc061d0f87156769feb16b6a81e97462ef6cee \
 				github.com/caddy-dns/namecheap@7095083a353829fc83632c34e8988fd8eb72f43d \
-				github.com/caddy-dns/netlify@eaa9514e3b9fda329b317b937e2c6c0f23d11356 \
 				github.com/caddy-dns/acmedns@18621dd3e69e048eae80c4171ef56cb576dce2f4 \
 				github.com/caddy-dns/desec@822a6a2014b221e8fa589fbcfd0395abe9ee90f6 \
 				github.com/caddy-dns/powerdns@fbd76808d64f57c80d4d62587dd14b14f06aefc7 \
-				github.com/caddy-dns/ddnss@7f65108b0a6249d8e630fe2431143069c4317ee4 \
-				github.com/caddy-dns/njalla@57869f89026a2e8980d1b3fac5687e115e9acb36 \
 				github.com/caddy-dns/linode@6fa218b5e8d6495dd96359b5550937f10234b360 \
-				github.com/caddy-dns/tencentcloud@d0f5c8c8114232a2c04f6912fb5de54d02e58245 \
-				github.com/caddy-dns/dinahosting@38b1acca4e37dac795cdd2ec239acb4fc3df7fef \
 				github.com/caddy-dns/ionos@041b720e83ffd1245086edf4b0259a802fc586ba \
 				github.com/caddy-dns/hexonet@2df0595f17b1cae63394c9488eec55f4c1b63650 \
 				github.com/caddy-dns/mailinabox@39d0e3ce8e259f6d1b98b6c417fc79a0a1708e91 \
@@ -126,14 +118,11 @@ CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d
 				github.com/caddy-dns/rfc2136@b8df5e8730c9dcd6fce4b483530b96dcd46c0690 \
 				github.com/caddy-dns/dnsmadeeasy@429f104d55d714143ebdcbf3e3effdc9039572e0 \
 				github.com/caddy-dns/bunny@71ced26b4224a713a918171a72c30c9908b59793 \
-				github.com/caddy-dns/civo@e2766c887ff53e6d24eb2646bbae85af77f41a78 \
 				github.com/caddy-dns/scaleway@561fd7f77b1b2022b4fd59d386179bfa65adebef \
 				github.com/caddy-dns/acmeproxy@69e9771dee25b5b7b8061f91e989e14573286e17 \
 				github.com/caddy-dns/inwx@706fe28db5b3f0017e735b46ef63d11c6db0112d \
 				github.com/caddy-dns/namedotcom@b9fae156cd97e1720f20aa03d82f96d2cf773e7a \
-				github.com/caddy-dns/easydns@9f2603a3f99463d342027831014f0a3330111f4c \
 				github.com/caddy-dns/infomaniak@3755ae5b26f7bc73a94722ccd1abac8e3097bdd5 \
 				github.com/caddy-dns/directadmin@48e27a0b9ce8e7bceda884e4e26e00461b674413 \
-				github.com/caddy-dns/hosttech@706ade8378b237a618bba8610a4c30da403a536e \
 				github.com/caddy-dns/vultr@35618104157e8c72189928769d497cc37001a741 \
 				github.com/caddy-dns/hetzner@23343c04385f08c188b3f43f7c21e5f6a65dedcb


### PR DESCRIPTION
Update caddy-l4 module. Remove DNS Provider dependencies that pull big external deps/sdks into the binary.

For: https://github.com/opnsense/plugins/issues/4437

Fixes: https://github.com/opnsense/plugins/issues/4384