### PR TITLE
build/common: load device-specific environment before setting SRCABI

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -233,7 +233,6 @@ SRCREVISION=unknown
 if [ -f ${SRCDIR}/sys/conf/newvers.sh ]; then
 	eval export SRC$(grep ^REVISION= ${SRCDIR}/sys/conf/newvers.sh)
 fi
-export SRCABI="FreeBSD:${SRCREVISION%%.*}:${PRODUCT_ARCH}"
 
 if [ ! -f ${DEVICEDIR}/${PRODUCT_DEVICE_REAL}.conf ]; then
 	echo ">>> No configuration found for device ${PRODUCT_DEVICE_REAL}." >&2
@@ -242,6 +241,7 @@ fi
 
 # load device-specific environment
 . ${DEVICEDIR}/${PRODUCT_DEVICE_REAL}.conf
+export SRCABI="FreeBSD:${SRCREVISION%%.*}:${PRODUCT_ARCH}"
 
 # define and bootstrap target directories
 export STAGEDIR="${STAGEDIRPREFIX}${CONFIGDIR}/${PRODUCT_ARCH}"


### PR DESCRIPTION
`PRODUCT_ARCH` can be defined in device file, hence device file must be loaded first.

Currently, `make prefetch DEVICE=ARM64 MIRRORS=<custom mirror>` fails on amd64 build systems because `SRCABI` is incorrectly set to `FreeBSD:14:amd64`.

[Bug report by @mnaiman](https://github.com/maurice-w/opnsense-vm-images/issues/6#issuecomment-2648416749)