### PR TITLE
www/caddy-custom: Revise build for caddy-v2.10.0

### DIFF
--- a/config/25.1/make.conf
+++ b/config/25.1/make.conf
@@ -98,8 +98,8 @@ www_squid_UNSET=		AUTH_NIS TP_IPFW
 www_webgrind_SET=		CALLGRAPH
 
 # for www/caddy-custom
-CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d06a83964da5573ee6a51f \
-				github.com/mholt/caddy-dynamicdns@7c818ab3fc3485a72a346f85c77810725f19f9cf \
-				github.com/mholt/caddy-l4@87e3e5e2c7f986b34c0df373a5799670d7b8ca03 \
-				github.com/mholt/caddy-ratelimit@a8e9f68d7bedc7ddb0c5bb93d6d32d8cf75fcc9f \
-				github.com/caddy-dns/cloudflare@bbf79111721a977fbd13dfe1f5b7aacaf7871a75
+CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport \
+				github.com/mholt/caddy-dynamicdns \
+				github.com/mholt/caddy-l4 \
+				github.com/mholt/caddy-ratelimit \
+				github.com/caddy-dns/cloudflare

--- a/config/25.1/make.conf
+++ b/config/25.1/make.conf
@@ -100,31 +100,6 @@ www_webgrind_SET=		CALLGRAPH
 # for www/caddy-custom
 CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport@e0c1e46a30093fa243d06a83964da5573ee6a51f \
 				github.com/mholt/caddy-dynamicdns@7c818ab3fc3485a72a346f85c77810725f19f9cf \
-				github.com/mholt/caddy-l4@6e5f5e311ead9de02c96c44e071947ab273b1f59 \
-				github.com/mholt/caddy-ratelimit@12435ecef5dbb1b137eb68002b85d775a9d5cdb2 \
-				github.com/caddy-dns/cloudflare@89f16b99c18ef49c8bb470a82f895bce01cbaece \
-				github.com/caddy-dns/duckdns@77870e12bac552ceb76917d82ced6db84b958c1f \
-				github.com/caddy-dns/gandi@d814cce86812e1e78544496e8f79e725058d8f1a \
-				github.com/caddy-dns/azure@f2351591d9f258201499abc37d054b7e6366fefb \
-				github.com/caddy-dns/porkbun@6b466fe4a00ba161d78669f048602ac70e706076 \
-				github.com/caddy-dns/ovh@62cc061d0f87156769feb16b6a81e97462ef6cee \
-				github.com/caddy-dns/namecheap@7095083a353829fc83632c34e8988fd8eb72f43d \
-				github.com/caddy-dns/acmedns@18621dd3e69e048eae80c4171ef56cb576dce2f4 \
-				github.com/caddy-dns/desec@822a6a2014b221e8fa589fbcfd0395abe9ee90f6 \
-				github.com/caddy-dns/powerdns@fbd76808d64f57c80d4d62587dd14b14f06aefc7 \
-				github.com/caddy-dns/linode@6fa218b5e8d6495dd96359b5550937f10234b360 \
-				github.com/caddy-dns/ionos@041b720e83ffd1245086edf4b0259a802fc586ba \
-				github.com/caddy-dns/hexonet@2df0595f17b1cae63394c9488eec55f4c1b63650 \
-				github.com/caddy-dns/mailinabox@39d0e3ce8e259f6d1b98b6c417fc79a0a1708e91 \
-				github.com/caddy-dns/netcup@a811da94403509715bd149669b07544706fd6d46 \
-				github.com/caddy-dns/rfc2136@b8df5e8730c9dcd6fce4b483530b96dcd46c0690 \
-				github.com/caddy-dns/dnsmadeeasy@429f104d55d714143ebdcbf3e3effdc9039572e0 \
-				github.com/caddy-dns/bunny@71ced26b4224a713a918171a72c30c9908b59793 \
-				github.com/caddy-dns/scaleway@561fd7f77b1b2022b4fd59d386179bfa65adebef \
-				github.com/caddy-dns/acmeproxy@69e9771dee25b5b7b8061f91e989e14573286e17 \
-				github.com/caddy-dns/inwx@706fe28db5b3f0017e735b46ef63d11c6db0112d \
-				github.com/caddy-dns/namedotcom@b9fae156cd97e1720f20aa03d82f96d2cf773e7a \
-				github.com/caddy-dns/infomaniak@3755ae5b26f7bc73a94722ccd1abac8e3097bdd5 \
-				github.com/caddy-dns/directadmin@48e27a0b9ce8e7bceda884e4e26e00461b674413 \
-				github.com/caddy-dns/vultr@35618104157e8c72189928769d497cc37001a741 \
-				github.com/caddy-dns/hetzner@23343c04385f08c188b3f43f7c21e5f6a65dedcb
+				github.com/mholt/caddy-l4@87e3e5e2c7f986b34c0df373a5799670d7b8ca03 \
+				github.com/mholt/caddy-ratelimit@a8e9f68d7bedc7ddb0c5bb93d6d32d8cf75fcc9f \
+				github.com/caddy-dns/cloudflare@bbf79111721a977fbd13dfe1f5b7aacaf7871a75


### PR DESCRIPTION
https://github.com/opnsense/plugins/issues/4643

Reasons are explained in above ticket. To be merged when caddy-v2.10.0 hits the road. Merging it beforehand will make the current caddy build fail.

- Remove commit hashes requirement

Since our build is very lean now, compatibility issues between different modules are not a pressing issue anymore.

The exact versions of modules can be more lenient, as build issues will be very rare now.

The dependency which made builds fail has always been libdns, which is now on version 1.0.0, and hopefully will not introduce breaking changes anymore. Libdns is an integral dependency of caddy itself, and a dependency of dynamic-dns and cloudflare, as well as any other dns provider.

Removing the DNS providers from the standard build will remove the need for careful commit hash management, as its unlikely that mainline caddy modules like cloudflare, dynamic-dns and caddy itself will become incompatible with each other, as most of their userbase rely on this.

https://github.com/libdns/libdns/releases/tag/v1.0.0