### PR TITLE
Add www/xcaddy and its dependency lang/go

### DIFF
--- a/config/25.1/plugins.conf
+++ b/config/25.1/plugins.conf
@@ -10,6 +10,7 @@ dns/dnscrypt-proxy				arm
 dns/rfc2136
 emulators/qemu-guest-agent			arm
 ftp/tftp
+lang/go						arm
 mail/postfix					arm
 mail/rspamd					arm
 misc/theme-advanced
@@ -96,6 +97,7 @@ www/OPNProxy					arm
 www/c-icap					arm
 www/cache
 www/caddy					arm
+www/xcaddy					arm
 www/nginx					arm
 www/squid
 www/web-proxy-sso				arm


### PR DESCRIPTION
www/xcaddy is a wrapper around lang/go that can build caddy with custom modules.

When installing xcaddy as package, it will also install lang/go as dependency.

lang/go does not have to be an exact version, it is sufficient to be 1.21 or higher, which the default version of freebsd supplies.

When a binary is built with lang/go, lang/go can automatically update its toolchain during the build.

As an example, these have been built directly from ports with ```make install clean```

```
root@opn-dev-01:/ # pkg remove go
Installed packages to be REMOVED:
	go: 1.21_5,2
	xcaddy: 0.4.2_3
```

Running the build still gives the expected result:

```
2025/05/08 17:18:56 [INFO] exec (timeout=0s): /usr/local/bin/go get -d -v github.com/caddyserver/caddy/v2 
go: github.com/caddyserver/caddy/v2@v2.10.0 requires go >= 1.24; switching to go1.24.3
```

```
root@opn-dev-01: # caddy build-info
go	go1.24.3
path	caddy
```