### PR TITLE
Update port configs to support arm64 ignore chipsets

### DIFF
--- a/config/25.1/aux.conf
+++ b/config/25.1/aux.conf
@@ -1,7 +1,7 @@
 #ORIGIN						IGNORE
 devel/binutils
 devel/cmake-core
-lang/go121					arm
-lang/go122					arm
-lang/go123					arm
-lang/rust					arm
+lang/go121					arm,arm64
+lang/go122					arm,arm64
+lang/go123					arm,arm64
+lang/rust					arm,arm64

--- a/config/25.1/plugins.conf
+++ b/config/25.1/plugins.conf
@@ -1,101 +1,101 @@
 #ORIGIN						IGNORE
-benchmarks/iperf				arm
-databases/redis					arm
-devel/debug					arm
+benchmarks/iperf				arm,arm64
+databases/redis					arm,arm64
+devel/debug					arm,arm64
 devel/grid_example
 devel/helloworld
-dns/bind					arm
+dns/bind					arm,arm64
 dns/ddclient
-dns/dnscrypt-proxy				arm
+dns/dnscrypt-proxy				arm,arm64
 dns/rfc2136
-emulators/qemu-guest-agent			arm
+emulators/qemu-guest-agent			arm,arm64
 ftp/tftp
-mail/postfix					arm
-mail/rspamd					arm
+mail/postfix					arm,arm64
+mail/rspamd					arm,arm64
 misc/theme-advanced
 misc/theme-cicada
 misc/theme-rebellion
 misc/theme-tukan
 misc/theme-vicuna
-net-mgmt/collectd				arm
-net-mgmt/lldpd					arm
-net-mgmt/net-snmp				arm
-net-mgmt/netdata				arm
-net-mgmt/nrpe					arm
-net-mgmt/telegraf				arm
-net-mgmt/zabbix-agent@zabbix5			arm
-net-mgmt/zabbix-agent@zabbix6			arm
-net-mgmt/zabbix-agent@zabbix7			arm
-net-mgmt/zabbix-agent@zabbix72			arm
-net-mgmt/zabbix-proxy@zabbix5			arm
-net-mgmt/zabbix-proxy@zabbix6			arm
-net-mgmt/zabbix-proxy@zabbix7			arm
-net-mgmt/zabbix-proxy@zabbix72			arm
-net/chrony					arm
-net/freeradius					arm
-net/frr						arm
+net-mgmt/collectd				arm,arm64
+net-mgmt/lldpd					arm,arm64
+net-mgmt/net-snmp				arm,arm64
+net-mgmt/netdata				arm,arm64
+net-mgmt/nrpe					arm,arm64
+net-mgmt/telegraf				arm,arm64
+net-mgmt/zabbix-agent@zabbix5			arm,arm64
+net-mgmt/zabbix-agent@zabbix6			arm,arm64
+net-mgmt/zabbix-agent@zabbix7			arm,arm64
+net-mgmt/zabbix-agent@zabbix72			arm,arm64
+net-mgmt/zabbix-proxy@zabbix5			arm,arm64
+net-mgmt/zabbix-proxy@zabbix6			arm,arm64
+net-mgmt/zabbix-proxy@zabbix7			arm,arm64
+net-mgmt/zabbix-proxy@zabbix72			arm,arm64
+net/chrony					arm,arm64
+net/freeradius					arm,arm64
+net/frr						arm,arm64
 net/ftp-proxy
-net/google-cloud-sdk				arm
-net/haproxy					arm
+net/google-cloud-sdk				arm,arm64
+net/haproxy					arm,arm64
 net/igmp-proxy
 net/mdns-repeater
 net/ndproxy
-net/ntopng					arm
-net/radsecproxy					arm
+net/ntopng					arm,arm64
+net/radsecproxy					arm,arm64
 net/realtek-re
-net/relayd					arm
-net/shadowsocks					arm
-net/siproxd					arm
+net/relayd					arm,arm64
+net/shadowsocks					arm,arm64
+net/siproxd					arm,arm64
 net/sslh
-net/tayga					arm
-net/turnserver					arm
-net/udpbroadcastrelay				arm
+net/tayga					arm,arm64
+net/turnserver					arm,arm64
+net/udpbroadcastrelay				arm,arm64
 net/upnp
-net/vnstat					arm
+net/vnstat					arm,arm64
 net/wol
-net/zerotier					arm
+net/zerotier					arm,arm64
 security/acme-client
-security/clamav					arm
-security/crowdsec				arm
+security/clamav					arm,arm64
+security/crowdsec				arm,arm64
 security/etpro-telemetry
 security/intrusion-detection-content-et-open
 security/intrusion-detection-content-et-pro
 security/intrusion-detection-content-pt-open
 security/intrusion-detection-content-snort-vrt
-security/maltrail				arm
-security/openconnect				arm
-security/softether				arm
-security/stunnel				arm
-security/tailscale				arm
-security/tinc					arm
-security/tor					arm
-security/wazuh-agent				arm
-sysutils/apcupsd				arm
-sysutils/apuled					arm
-sysutils/beats					arm
-sysutils/cpu-microcode@amd			arm,aarch64
-sysutils/cpu-microcode@intel			arm,aarch64
-sysutils/dec-hw					arm,aarch64
-sysutils/dmidecode				arm
+security/maltrail				arm,arm64
+security/openconnect				arm,arm64
+security/softether				arm,arm64
+security/stunnel				arm,arm64
+security/tailscale				arm,arm64
+security/tinc					arm,arm64
+security/tor					arm,arm64
+security/wazuh-agent				arm,arm64
+sysutils/apcupsd				arm,arm64
+sysutils/apuled					arm,arm64
+sysutils/beats					arm,arm64
+sysutils/cpu-microcode@amd			arm,arm64,aarch64
+sysutils/cpu-microcode@intel			arm,arm64,aarch64
+sysutils/dec-hw					arm,arm64,aarch64
+sysutils/dmidecode				arm,arm64
 sysutils/gdrive-backup
 sysutils/git-backup
-sysutils/hw-probe				arm
-sysutils/lcdproc-sdeclcd			arm,aarch64
-sysutils/munin-node				arm
+sysutils/hw-probe				arm,arm64
+sysutils/lcdproc-sdeclcd			arm,arm64,aarch64
+sysutils/munin-node				arm,arm64
 sysutils/nextcloud-backup
-sysutils/node_exporter				arm
-sysutils/nut					arm,aarch64
-sysutils/puppet-agent				arm
+sysutils/node_exporter				arm,arm64
+sysutils/nut					arm,arm64,aarch64
+sysutils/puppet-agent				arm,arm64
 sysutils/sftp-backup
-sysutils/smart					arm
-sysutils/virtualbox				arm,aarch64
-sysutils/vmware					arm
-sysutils/xen					arm,aarch64
-vendor/sunnyvalley				arm,aarch64
-www/OPNProxy					arm
-www/c-icap					arm
+sysutils/smart					arm,arm64
+sysutils/virtualbox				arm,arm64,aarch64
+sysutils/vmware					arm,arm64
+sysutils/xen					arm,arm64,aarch64
+vendor/sunnyvalley				arm,arm64,aarch64
+www/OPNProxy					arm,arm64
+www/c-icap					arm,arm64
 www/cache
-www/caddy					arm
-www/nginx					arm
+www/caddy					arm,arm64
+www/nginx					arm,arm64
 www/squid
-www/web-proxy-sso				arm
+www/web-proxy-sso				arm,arm64

--- a/config/25.1/ports.conf
+++ b/config/25.1/ports.conf
@@ -1,29 +1,29 @@
 #ORIGIN						IGNORE
 archivers/php${PRODUCT_PHP}-zlib
-archivers/snappy				arm
+archivers/snappy				arm,arm64
 archivers/zip
-audio/beep					arm,aarch64
-benchmarks/iperf3				arm
-benchmarks/stress-ng				arm
-comms/gnokii					arm
+audio/beep					arm,arm64,aarch64
+benchmarks/iperf3				arm,arm64
+benchmarks/stress-ng				arm,arm64
+comms/gnokii					arm,arm64
 converters/base64
-converters/php${PRODUCT_PHP}-mbstring		arm
-databases/hiredis				arm
-databases/p5-DBD-Pg				arm
-databases/p5-DBD-Sybase				arm
-databases/pecl-mongodb				arm
-databases/php${PRODUCT_PHP}-mysqli		arm
+converters/php${PRODUCT_PHP}-mbstring		arm,arm64
+databases/hiredis				arm,arm64
+databases/p5-DBD-Pg				arm,arm64
+databases/p5-DBD-Sybase				arm,arm64
+databases/pecl-mongodb				arm,arm64
+databases/php${PRODUCT_PHP}-mysqli		arm,arm64
 databases/php${PRODUCT_PHP}-sqlite3
-math/py-bottleneck@py${PRODUCT_PYTHON}		arm # XXX unbreak py-duckdb
-databases/py-duckdb@py${PRODUCT_PYTHON}		arm
-databases/py-redis@py${PRODUCT_PYTHON}		arm
+math/py-bottleneck@py${PRODUCT_PYTHON}		arm,arm64 # XXX unbreak py-duckdb
+databases/py-duckdb@py${PRODUCT_PYTHON}		arm,arm64
+databases/py-redis@py${PRODUCT_PYTHON}		arm,arm64
 databases/py-sqlite3@py${PRODUCT_PYTHON}
-databases/pymongo				arm
-databases/redis72				arm
+databases/pymongo				arm,arm64
+databases/redis72				arm,arm64
 databases/rrdtool
-devel/arcanist@php${PRODUCT_PHP}		arm
+devel/arcanist@php${PRODUCT_PHP}		arm,arm64
 devel/automake
-devel/awscli					arm
+devel/awscli					arm,arm64
 devel/bison
 devel/gdb
 devel/gettext
@@ -33,10 +33,10 @@ devel/git
 devel/gmake
 devel/libtool
 devel/ninja
-devel/p5-File-Slurp				arm
-devel/p5-Locale-Maketext-Lexicon		arm
+devel/p5-File-Slurp				arm,arm64
+devel/p5-Locale-Maketext-Lexicon		arm,arm64
 devel/patch
-devel/pear-PHP_CodeSniffer@php${PRODUCT_PHP}	arm
+devel/pear-PHP_CodeSniffer@php${PRODUCT_PHP}	arm,arm64
 devel/pecl-xdebug
 devel/php${PRODUCT_PHP}-gettext
 devel/php${PRODUCT_PHP}-pcntl
@@ -49,11 +49,11 @@ devel/py-setuptools@py${PRODUCT_PYTHON}
 devel/py-ujson@py${PRODUCT_PYTHON}
 devel/scons
 dns/bind-tools
-dns/bind920					arm
+dns/bind920					arm,arm64
 dns/ddclient
-dns/dnscrypt-proxy2				arm
+dns/dnscrypt-proxy2				arm,arm64
 dns/dnsmasq
-dns/getdns					arm
+dns/getdns					arm,arm64
 dns/py-dns-lexicon@py${PRODUCT_PYTHON}
 dns/py-dnspython@py${PRODUCT_PYTHON}
 dns/unbound
@@ -61,105 +61,105 @@ editors/emacs@nox
 editors/joe
 editors/nano
 editors/vim
-emulators/open-vm-tools-nox11			arm
-emulators/qemu@guestagent			arm
-emulators/virtualbox-ose-additions-nox11	arm,aarch64
+emulators/open-vm-tools-nox11			arm,arm64
+emulators/qemu@guestagent			arm,arm64
+emulators/virtualbox-ose-additions-nox11	arm,arm64,aarch64
 ftp/curl
 ftp/php${PRODUCT_PHP}-curl
 ftp/tftp-hpa
-ftp/uftp					arm
-ftp/wget					arm
+ftp/uftp					arm,arm64
+ftp/wget					arm,arm64
 lang/perl${PRODUCT_PERL}
 lang/php${PRODUCT_PHP}
 lang/python${PRODUCT_PYTHON}
-lang/ruby${PRODUCT_RUBY}			arm
-mail/pecl-mailparse				arm
-mail/phpmailer					arm
-mail/postfix					arm
-mail/rspamd					arm
-mail/smtp-cli					arm
-math/php${PRODUCT_PHP}-bcmath			arm
+lang/ruby${PRODUCT_RUBY}			arm,arm64
+mail/pecl-mailparse				arm,arm64
+mail/phpmailer					arm,arm64
+mail/postfix					arm,arm64
+mail/rspamd					arm,arm64
+mail/smtp-cli					arm,arm64
+math/php${PRODUCT_PHP}-bcmath			arm,arm64
 misc/getopt
-misc/gnu-watch					arm
+misc/gnu-watch					arm,arm64
 misc/help2man
-misc/mc-nox11					arm
-devel/py-frozenlist@py${PRODUCT_PYTHON}		arm # XXX unbreak py-telepot
-www/py-yarl@py${PRODUCT_PYTHON}			arm # XXX unbreak py-telepot
-net-im/py-telepot@py${PRODUCT_PYTHON}		arm
-net-mgmt/bwm-ng					arm
-net-mgmt/check_mk_agent				arm
+misc/mc-nox11					arm,arm64
+devel/py-frozenlist@py${PRODUCT_PYTHON}		arm,arm64 # XXX unbreak py-telepot
+www/py-yarl@py${PRODUCT_PYTHON}			arm,arm64 # XXX unbreak py-telepot
+net-im/py-telepot@py${PRODUCT_PYTHON}		arm,arm64
+net-mgmt/bwm-ng					arm,arm64
+net-mgmt/check_mk_agent				arm,arm64
 net-mgmt/choparp
-net-mgmt/collectd5				arm
+net-mgmt/collectd5				arm,arm64
 net-mgmt/flowd
-net-mgmt/icinga2				arm
+net-mgmt/icinga2				arm,arm64
 net-mgmt/iftop
-net-mgmt/lldpd					arm
-net-mgmt/net-snmp				arm
-net-mgmt/netdata				arm
-net-mgmt/nrpe					arm
+net-mgmt/lldpd					arm,arm64
+net-mgmt/net-snmp				arm,arm64
+net-mgmt/netdata				arm,arm64
+net-mgmt/nrpe					arm,arm64
 net-mgmt/p5-FusionInventory-Agent
 net-mgmt/py-opn-cli
-net-mgmt/telegraf				arm
-net-mgmt/xymon-client				arm
-net-mgmt/yaf					arm
-net-mgmt/zabbix5-agent				arm
-net-mgmt/zabbix5-proxy				arm
-net-mgmt/zabbix6-agent				arm
-net-mgmt/zabbix6-proxy				arm
-net-mgmt/zabbix7-agent				arm
-net-mgmt/zabbix7-proxy				arm
-net-mgmt/zabbix72-agent				arm
-net-mgmt/zabbix72-proxy				arm
-net/addrwatch					arm
-net/bird2					arm
-net/chrony					arm
+net-mgmt/telegraf				arm,arm64
+net-mgmt/xymon-client				arm,arm64
+net-mgmt/yaf					arm,arm64
+net-mgmt/zabbix5-agent				arm,arm64
+net-mgmt/zabbix5-proxy				arm,arm64
+net-mgmt/zabbix6-agent				arm,arm64
+net-mgmt/zabbix6-proxy				arm,arm64
+net-mgmt/zabbix7-agent				arm,arm64
+net-mgmt/zabbix7-proxy				arm,arm64
+net-mgmt/zabbix72-agent				arm,arm64
+net-mgmt/zabbix72-proxy				arm,arm64
+net/addrwatch					arm,arm64
+net/bird2					arm,arm64
+net/chrony					arm,arm64
 net/dpinger
-net/freeradius3					arm
-net/frr8-pythontools				arm
-net/google-cloud-sdk				arm
-net/haproxy					arm
+net/freeradius3					arm,arm64
+net/frr8-pythontools				arm,arm64
+net/google-cloud-sdk				arm,arm64
+net/haproxy					arm,arm64
 net/hostapd
 net/igmpproxy
 net/isc-dhcp44-server
 net/kea
-net/lua-luasocket				arm
+net/lua-luasocket				arm,arm64
 net/mdns-repeater
 net/miniupnpd
-net/mosquitto					arm
+net/mosquitto					arm,arm64
 net/mpd5
-net/mtr@nox11					arm
+net/mtr@nox11					arm,arm64
 net/ndproxy
-net/ntopng					arm
+net/ntopng					arm,arm64
 net/ntp
-net/ocserv					arm
-net/openldap26-client				arm
-net/openldap26-server				arm
-net/p5-Net-SIP					arm
+net/ocserv					arm,arm64
+net/openldap26-client				arm,arm64
+net/openldap26-server				arm,arm64
+net/p5-Net-SIP					arm,arm64
 net/pecl-radius
 net/php${PRODUCT_PHP}-ldap
-net/php${PRODUCT_PHP}-soap			arm
+net/php${PRODUCT_PHP}-soap			arm,arm64
 net/php${PRODUCT_PHP}-sockets
-net/pimd					arm
+net/pimd					arm,arm64
 net/py-ldap3@py${PRODUCT_PYTHON}
 net/py-netaddr@py${PRODUCT_PYTHON}
 net/py-speedtest-cli@py${PRODUCT_PYTHON}
-net/radsecproxy					arm
+net/radsecproxy					arm,arm64
 net/radvd
 net/realtek-re-kmod
-net/relayd					arm
-net/rsync					arm
+net/relayd					arm,arm64
+net/rsync					arm,arm64
 net/samplicator
 net/scapy
-net/shadowsocks-libev				arm
-net/shadowsocks-rust				arm,aarch64
-net/siproxd					arm
+net/shadowsocks-libev				arm,arm64
+net/shadowsocks-rust				arm,arm64,aarch64
+net/siproxd					arm,arm64
 net/sslh
-net/tayga					arm
-net/turnserver					arm
-net/udpbroadcastrelay				arm
-net/vnstat					arm
+net/tayga					arm,arm64
+net/turnserver					arm,arm64
+net/udpbroadcastrelay				arm,arm64
+net/vnstat					arm,arm64
 net/wol
-net/zerotier					arm
+net/zerotier					arm,arm64
 opnsense/cpustats
 opnsense/dhcp6c
 opnsense/dhcrelay
@@ -168,27 +168,27 @@ opnsense/google-api-php-client@php${PRODUCT_PHP}
 opnsense/ifinfo
 opnsense/installer
 opnsense/lang
-opnsense/mod_proxy_msrpc			arm
-opnsense/netmap-bridge				arm
+opnsense/mod_proxy_msrpc			arm,arm64
+opnsense/netmap-bridge				arm,arm64
 opnsense/pam
 opnsense/phpseclib@php${PRODUCT_PHP}
-opnsense/py-haproxy-cli				arm
+opnsense/py-haproxy-cli				arm,arm64
 opnsense/update
 ports-mgmt/pkg
-print/cups					arm
+print/cups					arm,arm64
 print/texinfo
 security/${PRODUCT_SSL}
 security/acme.sh
-security/autossh				arm
+security/autossh				arm,arm64
 security/ca_root_nss
-security/clamav					arm
-security/crowdsec				arm
-security/cyrus-sasl2-gssapi			arm
+security/clamav					arm,arm64
+security/crowdsec				arm,arm64
+security/cyrus-sasl2-gssapi			arm,arm64
 security/expiretable
-security/gnupg					arm
-security/maltrail				arm
-security/nmap					arm
-security/openconnect				arm
+security/gnupg					arm,arm64
+security/maltrail				arm,arm64
+security/nmap					arm,arm64
+security/openconnect				arm,arm64
 security/openssh-portable
 security/openvpn
 security/pear-Crypt_CHAP@php${PRODUCT_PHP}
@@ -196,82 +196,82 @@ security/php${PRODUCT_PHP}-filter
 security/py-fail2ban@py${PRODUCT_PYTHON}
 security/py-vici@py${PRODUCT_PYTHON}
 security/snuffleupagus@php${PRODUCT_PHP}
-security/softether				arm
-security/sslproxy				arm
-security/sslscan				arm
+security/softether				arm,arm64
+security/sslproxy				arm,arm64
+security/sslscan				arm,arm64
 security/strongswan
-security/stunnel				arm
+security/stunnel				arm,arm64
 security/sudo
-security/suricata				arm
-security/tailscale				arm
-security/tinc					arm
-security/tor					arm
-security/wazuh-agent				arm
+security/suricata				arm,arm64
+security/tailscale				arm,arm64
+security/tinc					arm,arm64
+security/tor					arm,arm64
+security/wazuh-agent				arm,arm64
 security/wpa_supplicant
-security/xray-core				arm
-security/yara					arm
-sysutils/ansible@py${PRODUCT_PYTHON}		arm
-sysutils/apcupsd				arm
-sysutils/azure-agent				arm
+security/xray-core				arm,arm64
+security/yara					arm,arm64
+sysutils/ansible@py${PRODUCT_PYTHON}		arm,arm64
+sysutils/apcupsd				arm,arm64
+sysutils/azure-agent				arm,arm64
 sysutils/bastille
-sysutils/beats8					arm
-sysutils/burp					arm
-sysutils/cciss_vol_status			arm
-sysutils/cpu-microcode-amd			arm,aarch64
-sysutils/cpu-microcode-intel			arm,aarch64
-sysutils/dmidecode				arm
+sysutils/beats8					arm,arm64
+sysutils/burp					arm,arm64
+sysutils/cciss_vol_status			arm,arm64
+sysutils/cpu-microcode-amd			arm,arm64,aarch64
+sysutils/cpu-microcode-intel			arm,arm64,aarch64
+sysutils/dmidecode				arm,arm64
 sysutils/ethname
-sysutils/flashrom				arm,aarch64
+sysutils/flashrom				arm,arm64,aarch64
 sysutils/flock
-sysutils/freecolor				arm
-sysutils/freeipmi				arm,aarch64
-sysutils/hw-probe				arm
-sysutils/iohyve					arm
-sysutils/lcdproc				arm,aarch64
-sysutils/logrotate				arm
-sysutils/lsof					arm
+sysutils/freecolor				arm,arm64
+sysutils/freeipmi				arm,arm64,aarch64
+sysutils/hw-probe				arm,arm64
+sysutils/iohyve					arm,arm64
+sysutils/lcdproc				arm,arm64,aarch64
+sysutils/logrotate				arm,arm64
+sysutils/lsof					arm,arm64
 sysutils/monit
-sysutils/msktutil				arm
-sysutils/multitail				arm
-sysutils/munin-node				arm
-sysutils/node_exporter				arm
-sysutils/nut					arm,aarch64
+sysutils/msktutil				arm,arm64
+sysutils/multitail				arm,arm64
+sysutils/munin-node				arm,arm64
+sysutils/node_exporter				arm,arm64
+sysutils/nut					arm,arm64,aarch64
 sysutils/pftop
-sysutils/pstree					arm
-sysutils/puppet7				arm
+sysutils/pstree					arm,arm64
+sysutils/puppet7				arm,arm64
 sysutils/screen
-sysutils/smartmontools				arm
-sysutils/superiotool				arm,aarch64
+sysutils/smartmontools				arm,arm64
+sysutils/superiotool				arm,arm64,aarch64
 sysutils/sysinfo
 sysutils/syslog-ng
 sysutils/tmux
 sysutils/usb_modeswitch
-sysutils/virt-what				arm
-sysutils/x86info				arm,aarch64
-sysutils/xe-guest-utilities			arm,aarch64
+sysutils/virt-what				arm,arm64
+sysutils/x86info				arm,arm64,aarch64
+sysutils/xe-guest-utilities			arm,arm64,aarch64
 textproc/jq
-textproc/minify					arm
+textproc/minify					arm,arm64
 textproc/php${PRODUCT_PHP}-ctype
 textproc/php${PRODUCT_PHP}-dom
 textproc/php${PRODUCT_PHP}-simplexml
 textproc/php${PRODUCT_PHP}-xml
 textproc/py-jq@py${PRODUCT_PYTHON}
-www/apache${PRODUCT_APACHE}			arm
-www/c-icap					arm
-www/c-icap-modules				arm
-www/caddy-custom				arm
-www/icapeg					arm
+www/apache${PRODUCT_APACHE}			arm,arm64
+www/c-icap					arm,arm64
+www/c-icap-modules				arm,arm64
+www/caddy-custom				arm,arm64
+www/icapeg					arm,arm64
 www/lighttpd
-www/mod_security				arm
-www/nginx					arm
+www/mod_security				arm,arm64
+www/nginx					arm,arm64
 www/phalcon@php${PRODUCT_PHP}
 www/php${PRODUCT_PHP}-opcache
 www/php${PRODUCT_PHP}-session
-www/privoxy					arm
-www/py-boto3@py${PRODUCT_PYTHON}		arm
+www/privoxy					arm,arm64
+www/py-boto3@py${PRODUCT_PYTHON}		arm,arm64
 www/py-requests@py${PRODUCT_PYTHON}
-www/sarg					arm
+www/sarg					arm,arm64
 www/squid
 www/squid-langpack
-www/webgrind					arm
-x11-fonts/urwfonts				arm
+www/webgrind					arm,arm64
+x11-fonts/urwfonts				arm,arm64


### PR DESCRIPTION
Newer RPIs and other devices, for example, now use arm64 chipsets.  Updated the ports, aux, and other configs to ignore the arm64 chipset during build for the same items that arm chipset is also ignored.

Example build log for an RPI 4

make command -> make base kernel packages arm-3G DEVICE=RPI DEBUG=1 

```
DEVICE=RPI
PRODUCT_ARCH=aarch64
PRODUCT_TARGET=arm64
```