### PR TITLE
config: add ncdu

### DIFF
--- a/config/25.1/ports.conf
+++ b/config/25.1/ports.conf
@@ -236,6 +236,7 @@ sysutils/monit
 sysutils/msktutil
 sysutils/multitail
 sysutils/munin-node
+sysutils/ncdu
 sysutils/node_exporter
 sysutils/nut					aarch64
 sysutils/pftop


### PR DESCRIPTION
This would be generally helpful to diagnose a full disk, and it has no dependencies.