### PR TITLE
ports: revert "exclude shadowsocks-rust on aarch64"

### DIFF
--- a/config/25.1/ports.conf
+++ b/config/25.1/ports.conf
@@ -147,7 +147,7 @@ net/rsync
 net/samplicator
 net/scapy
 net/shadowsocks-libev
-net/shadowsocks-rust				aarch64
+net/shadowsocks-rust
 net/siproxd
 net/sslh
 net/tayga

--- a/config/25.7/ports.conf
+++ b/config/25.7/ports.conf
@@ -147,7 +147,7 @@ net/rsync
 net/samplicator
 net/scapy
 net/shadowsocks-libev
-net/shadowsocks-rust				aarch64
+net/shadowsocks-rust
 net/siproxd
 net/sslh
 net/tayga


### PR DESCRIPTION
Build error fixed by upstream patch: opnsense/ports@8df2f48
Context: opnsense/plugins#4662