### PR TITLE
build/common: replacing mount_unionfs with mount_nullfs

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -480,7 +480,7 @@ setup_clone()
 	echo ">>> Setting up ${2} clone in ${1}"
 
 	# repositories may be huge so avoid the copy :)
-	mkdir -p ${1}${2} && mount_unionfs -o below ${2} ${1}${2}
+	mkdir -p ${1}${2} && mount_nullfs ${2} ${1}${2}
 }
 
 setup_copy()


### PR DESCRIPTION
Unionfs isn't a "jail friendly" filesystem and it can't be mounted inside jails.
Simply replacing the mount_unionfs with mount_nullfs helps to resolve this issue.
Yes, I'm aware that mount_unionfs had a '-o below' option and mount_nullfs doesn't support that, but that's the compromise.
So far I haven't had any other issues running the build system (make serial) in a jail other than the mount_unionfs problem.
Using jail requires several security settings, such as 'amount.mount', 'allow.mount.nullfs', 'enforce_statfs=1' to allow mounting filesystems inside.