### PR TITLE
enable some packages for aarch64

### DIFF
--- a/config/25.7/plugins.conf
+++ b/config/25.7/plugins.conf
@@ -86,7 +86,7 @@ sysutils/lcdproc-sdeclcd			aarch64
 sysutils/munin-node
 sysutils/nextcloud-backup
 sysutils/node_exporter
-sysutils/nut					aarch64
+sysutils/nut
 sysutils/puppet-agent
 sysutils/sftp-backup
 sysutils/smart

--- a/config/25.7/ports.conf
+++ b/config/25.7/ports.conf
@@ -155,7 +155,7 @@ net/tayga
 net/turnserver
 net/udpbroadcastrelay
 net/vnstat
-net/wifi-firmware-kmod				aarch64
+net/wifi-firmware-kmod
 net/wol
 net/zerotier
 opnsense/cpustats
@@ -218,7 +218,7 @@ sysutils/cpu-microcode-amd			aarch64
 sysutils/cpu-microcode-intel			aarch64
 sysutils/dmidecode
 sysutils/ethname
-sysutils/flashrom				aarch64
+sysutils/flashrom
 sysutils/flock
 sysutils/freecolor
 sysutils/freeipmi				aarch64
@@ -232,7 +232,7 @@ sysutils/msktutil
 sysutils/multitail
 sysutils/munin-node
 sysutils/node_exporter
-sysutils/nut					aarch64
+sysutils/nut
 sysutils/pftop
 sysutils/pstree
 sysutils/puppet8


### PR DESCRIPTION
I have successfully built these packages on aarch64 recently for OPNsense 24.7.3 without any modification, see http://168.138.176.159/opnsense/FreeBSD%3A14%3Aaarch64/25.7/MINT/25.7.3/latest/Latest/.