### PR TITLE
www/caddy-custom: Remove ntml-transport plugin

### DIFF
--- a/config/26.1/make.conf
+++ b/config/26.1/make.conf
@@ -100,8 +100,7 @@ www_squid_UNSET=		AUTH_NIS TP_IPFW
 www_webgrind_SET=		CALLGRAPH
 
 # for www/caddy-custom
-CADDY_CUSTOM_PLUGINS=		github.com/caddyserver/ntlm-transport \
-				github.com/mholt/caddy-dynamicdns \
+CADDY_CUSTOM_PLUGINS=		github.com/mholt/caddy-dynamicdns \
 				github.com/mholt/caddy-l4 \
 				github.com/mholt/caddy-ratelimit \
 				github.com/caddy-dns/cloudflare


### PR DESCRIPTION
For: https://github.com/opnsense/plugins/issues/5247