### PR TITLE
config: add amnezia-kmod, amnezia-tools, amneziawg-go to packages

### DIFF
--- a/config/26.1/ports.conf
+++ b/config/26.1/ports.conf
@@ -107,6 +107,9 @@ net-mgmt/zabbix72-proxy
 net-mgmt/zabbix74-agent
 net-mgmt/zabbix74-proxy
 net/addrwatch
+net/amnezia-kmod
+net/amnezia-tools
+net/amneziawg-go
 net/bird2
 net/chrony
 net/dpinger


### PR DESCRIPTION
OPNsense currently has a `xray-core` (#378) package for traffic obfuscation, but without a plugin for the web interface.

I propose to add support for the Amnezia VPN ( https://docs.amnezia.org/documentation/amnezia-wg/ ) protocol in OPNsense.

> Amnezia VPN is a VPN protocol that is backward compatible with the WireGuard VPN protocol. It offers protection against detection by Deep Packet Inspection (DPI) systems. At the same time, it retains the simplified architecture and high performance
>
> The Amnezia VPN protocol has issues with detection due to distinctive packet signatures. Amnezia addresses this problem by employing advanced obfuscation methods, allowing its traffic to blend seamlessly with regular internet traffic.


There are two open source plugins for managing Amnezia connections for OPNsense:

- https://github.com/MrTheory/os-amneziawg ( https://forum.opnsense.org/index.php?topic=51023.0 )
- https://github.com/antspopov/opnsense_amnezia_plugin

Adding `net/amnezia-kmod`, `net/amnezia-tools`, `net/amneziawg-go` packages to the OPNsense repository will make it easier to use these plugins.

`amnezia-kmod` - kernel module for Amnezia protocol (version 1.0 and 1.5, and partial support of 2.0).
`amnezia-tools` - userspace tooling for using and configuring Amnezia tunnels.
`amneziawg-go` - userspace protocol implementation from Amnezia team (https://github.com/amnezia-vpn/amneziawg-go/).

@fichtner, Please review this PR, thank you.
