### PR TITLE
bug fix: Add architecture specification for aquantia-atlantic-kmod

### DIFF
--- a/config/26.1/ports.conf
+++ b/config/26.1/ports.conf
@@ -154,7 +154,7 @@ net/vnstat
 net/wifi-firmware-kmod
 net/wol
 net/zerotier
-opnsense/aquantia-atlantic-kmod
+opnsense/aquantia-atlantic-kmod					aarch64
 opnsense/cpustats
 opnsense/dhcp6c
 opnsense/dhcrelay


### PR DESCRIPTION
unsupported as of now, causes an error, on aarch64 platforms