### PR TITLE
Add UNIONFS option to SMP-ARM configuration

### DIFF
--- a/config/26.1/SMP-ARM
+++ b/config/26.1/SMP-ARM
@@ -15,6 +15,7 @@ options		MROUTING
 options		PPS_SYNC
 options		RSS
 options		TCP_SIGNATURE
+options		UNIONFS
 
 # Additional built-in devices
 #device		bwi

--- a/config/26.1/SMP-ARM
+++ b/config/26.1/SMP-ARM
@@ -15,6 +15,8 @@ options		MROUTING
 options		PPS_SYNC
 options		RSS
 options		TCP_SIGNATURE
+
+# ARM specific
 options		UNIONFS
 
 # Additional built-in devices


### PR DESCRIPTION
UNIONFS required module for arm devices

Resolves issue: https://github.com/opnsense/tools/issues/508