### PR TITLE
Update vm.sh reduced constant disk writes

### DIFF
--- a/build/vm.sh
+++ b/build/vm.sh
@@ -129,7 +129,7 @@ EOF
 
 if [ -z "${PRODUCT_ZFS}" ]; then
 	cat >> ${STAGEDIR}/mnt/etc/fstab << EOF
-/dev/gpt/rootfs	/		ufs	rw	1	1
+/dev/gpt/rootfs	/		ufs	rw,noatime	1	1
 EOF
 	fi
 


### PR DESCRIPTION
This "noatime" tweak, reduced the OPNsense constant 50kb - 80kb disk writes that wear down the SSD / NVME.

Signed-off-by: Unicorn9x

https://github.com/freebsd/freebsd-src/pull/1834

